### PR TITLE
PLUME-16: Add Storm event & refactor extreme events interface

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ set(EE_PLUGIN_FILES_H
     ee_registry/ee_base.h
     ee_registry/ee_registry.h
     ee_registry/extreme_wind.h
+    ee_registry/storm.h
     plugin_types.h
 )
 
@@ -42,6 +43,7 @@ set(EE_PLUGIN_FILES_CC
     ee_plugin_registration.cc
     ee_registry/ee_registry.cc
     ee_registry/extreme_wind.cc
+    ee_registry/storm.cc
 )
 
 set(EE_PLUGIN_SOURCES

--- a/src/ee_plugin.cc
+++ b/src/ee_plugin.cc
@@ -9,11 +9,9 @@
  * does it submit to any jurisdiction.
  */
 #include <cmath>
-#include <map>
 #include <sstream>
 
 #include "atlas/field/Field.h"
-#include "atlas/functionspace.h"
 
 #include "ee_plugin.h"
 #include "healpix_utils.h"
@@ -34,6 +32,8 @@ EEPluginCore::EEPluginCore(const eckit::Configuration& conf) : PluginCore(conf) 
 }
 
 void EEPluginCore::setup() {
+    // Healpix - grid points & polygon mapping matrix
+    setHEALPixMapping();
     // initialize extremeEventList from config
     eckit::Log::info() << "Extreme event detection Plume plugin loading events... ";
     for (auto& ee : extremeEventConfig_) {
@@ -49,8 +49,7 @@ void EEPluginCore::setup() {
             }
         }
         if (hasRequiredParams) {
-            ee.set("vertical_levels", modelData().getInt("NFLEVG"));
-            extremeEvents_.push_back(ExtremeEventRegistry::instance().createEvent(ee.getString("name"), ee));
+            extremeEvents_.push_back(ExtremeEventRegistry::instance().createEvent(ee, modelData(), Point2HPcell_));
             eckit::Log::info() << ee.getString("name") << " ";
         }
     }
@@ -58,8 +57,6 @@ void EEPluginCore::setup() {
         eckit::Log::error() << "No extreme events loaded, the EE plugin will error, check configuration" << std::endl;
     }
     eckit::Log::info() << std::endl;
-    // Healpix - grid points & polygon mapping matrix
-    setHEALPixMapping();
 }
 
 void EEPluginCore::run() {
@@ -69,11 +66,11 @@ void EEPluginCore::run() {
         // Run the detection for each extreme event suite
         auto results = ee->detect(modelData());
         for (size_t idx = 0; idx < results.size(); ++idx) {
-            if (results[idx].detectedPoints.empty()) {
+            if (results[idx].detectedCells.empty()) {
                 // No actual points were detected for that instance of the event
                 continue;
             }
-            auto ee_polygon_points = cellToPolygons(results[idx].detectedPoints, Point2HPcell_, HPcell2polygon_);
+            auto ee_polygon_points = cellToPolygons(results[idx].detectedCells, HPcell2polygon_);
             if (enableNotification_) {
                 // Send notification for each polygon individually if enabled
                 for (auto& polygon : ee_polygon_points) {
@@ -82,7 +79,10 @@ void EEPluginCore::run() {
                     payload << "{\"step\":\"" << elapsedTime << "\",\"description\":\"" << results[idx].description
                             << "\",\"param\":\"" << results[idx].param << "\",\"levtype\":\"" << results[idx].levtype
                             << "\",\"levelist\":\"" << results[idx].levelist << "\"}";
-                    notificationHandler_.send(payload.str(), polygon);
+                    int status = notificationHandler_.send(payload.str(), polygon);
+                    if (status != 200 && status != 999) {
+                        eckit::Log::error() << "Could not send Aviso notification, error code " << status << std::endl;
+                    }
                 }
             }
             else {
@@ -94,8 +94,8 @@ void EEPluginCore::run() {
 
 void EEPluginCore::setHEALPixMapping() {
     // TODO: Should this plugin handle multiple functionspaces if fields passed are not all on the same mesh?
-    // Retrieve the function space from the first field found in the first extreme event
-    auto fs = modelData().getAtlasFieldShared(extremeEvents_[0]->requiredFields()[0]).functionspace();
+    // Retrieve the function space from the model data
+    auto fs = modelData().getAtlasFieldShared(modelData().listAvailableParameters("ATLAS_FIELD")[0]).functionspace();
     mapLonLatToHEALPixCell(healpixRes_, fs, Point2HPcell_, HPcell2polygon_);
 }
 
@@ -105,7 +105,7 @@ std::string EEPluginCore::modelStepStr() {
     }
     int seconds = static_cast<int>(std::round(modelData().getInt("NSTEP") * modelData().getDouble("TSTEP")));
     // Sub-hourly supported time units (except for seconds)
-    std::map<int, std::string> timeUnits = {{86400, "d"}, {3600, "h"}, {60, "m"}};
+    const std::vector<std::pair<int, std::string>> timeUnits = {{86400, "d"}, {3600, "h"}, {60, "m"}};
     for (const auto& unit : timeUnits) {
         if (seconds % unit.first == 0) {
             int quotient = seconds / unit.first;

--- a/src/ee_registry/README.md
+++ b/src/ee_registry/README.md
@@ -8,12 +8,14 @@ extreme event plugin configuration. Anchors can be used to avoid errors and dupl
 The `enabled` key is optional, it can be set to `false` to keep an event in the configuration but not run it in the plugin.
 This key is `true` by default if omitted.
 
+[Extreme wind](#extreme-wind)
+[Storm](#storm)
 
 ## Extreme wind
 
 ### Description
 
-This plugin with name `extreme_wind` detects winds above a specified threshold or within a specified range.
+This event with name `extreme_wind` detects winds above a specified threshold or within a specified range.
 It scans the fields that are in the `required_params`, computes the wind magnitude from the horizontal and vertical
 components (or only one of them if the other is not offered), and flags the grid points that exceed the threshold or
 fall in the range. The same `extreme_wind` event can be used to detect on several fields or several thresholds, via
@@ -79,3 +81,38 @@ instances:
 
 You can use a combination of surface and non surface fields in your parameters, based on the instances options,
 the extreme wind event will determine which instance should run on which fields.
+
+## Storm
+
+### Description
+
+This event with name `storm` uses a minimal definition solely based on 100m wind components to serve as baseline,
+but may be refined in the future. Detection is triggered when the wind (1+ grid point in the coarse cell) exceeds a
+given threshold over a specified time window.
+
+This event stores the wind speed for each grid point and each time step in the time window.
+
+The initial implementation of this event makes use of the `100u` and `100v` fields from GRIB 1.
+It will be migrated to GRIB 2 to use `u` and `v` at height level `100` in the future.
+
+### Configuration examples
+
+Only `100u` and `100v` fields are allowed at the moment. The event requires only two options:
+- The wind speed threshold: expressed in m/s, only two decimals of precision are used by the algorithm,
+so anything more precise will be truncated. The algorithm will throw an error if the number provided is negative.
+- The time window: expressed in minutes. If the time window is smaller than the internal model time step,
+the detection will run only on the current time step.
+
+```yaml
+parameters:
+  - &storm
+    - name: "100u"
+      type: "atlas_field"
+    - name: "100v"
+      type: "atlas_field"
+...
+name: "storm"
+required_params: *storm
+wind_speed_cutout: 20.0
+time_window: 60
+```

--- a/src/ee_registry/README.md
+++ b/src/ee_registry/README.md
@@ -99,8 +99,7 @@ It will be migrated to GRIB 2 to use `u` and `v` at height level `100` in the fu
 
 Only `100u` and `100v` fields are allowed at the moment. The event requires only two options:
 - The wind speed threshold: expressed in m/s, only two decimals of precision are used by the algorithm,
-so anything more precise will be truncated. Typical values of wind can be represented on 2 bytes, the algorithm will
-throw an error if the number provided is negative or too high to fit in 2 bytes.
+so anything more precise will be truncated. The algorithm will throw an error if the number provided is negative.
 - The time window: expressed in minutes. If the time window is smaller than the internal model time step,
 the detection will run only on the current time step.
 

--- a/src/ee_registry/README.md
+++ b/src/ee_registry/README.md
@@ -99,7 +99,8 @@ It will be migrated to GRIB 2 to use `u` and `v` at height level `100` in the fu
 
 Only `100u` and `100v` fields are allowed at the moment. The event requires only two options:
 - The wind speed threshold: expressed in m/s, only two decimals of precision are used by the algorithm,
-so anything more precise will be truncated. The algorithm will throw an error if the number provided is negative.
+so anything more precise will be truncated. Typical values of wind can be represented on 2 bytes, the algorithm will
+throw an error if the number provided is negative or too high to fit in 2 bytes.
 - The time window: expressed in minutes. If the time window is smaller than the internal model time step,
 the detection will run only on the current time step.
 

--- a/src/ee_registry/ee_base.h
+++ b/src/ee_registry/ee_base.h
@@ -42,8 +42,9 @@ public:
      *
      * @param config The configuration for the extreme event. Each event has a different set of options, see
      *               their documentation for more details.
+     * @param type The type of extreme event.
      */
-    ExtremeEvent(const eckit::LocalConfiguration& config) {
+    ExtremeEvent(const eckit::LocalConfiguration& config, const std::string& type) {
         for (const auto& param : config.getSubConfigurations("required_params")) {
             if (param.getString("type") == "atlas_field") {
                 requiredFields_.push_back(param.getString("name"));
@@ -53,7 +54,7 @@ public:
             }
         }
         ASSERT_MSG(!requiredFields_.empty(),
-                   "Event '" + type_ + "' has no configured required Atlas fields, detection will fail.");
+                   "Event '" + type + "' has no configured required Atlas fields, detection will fail.");
     };
 
     /// Virtual destructor.
@@ -61,12 +62,12 @@ public:
 
     /**
      * @brief A structure that represents the result of detecting the extreme event.
-     * 
+     *
      * This information can later be used to build an Aviso request allowing the receiver to create a MARS request
      * to retrieve the relevant data regarding the detected event.
      */
     struct DetectionData {
-        std::vector<int> detectedPoints;
+        std::set<int> detectedCells;
         std::string description, param, levtype, levelist;
     };
 

--- a/src/ee_registry/ee_registry.cc
+++ b/src/ee_registry/ee_registry.cc
@@ -17,11 +17,13 @@ void ExtremeEventRegistry::registerEvent(const std::string& eventName, ExtremeEv
     registry[eventName] = factory;
 }
 
-std::unique_ptr<ExtremeEvent> ExtremeEventRegistry::createEvent(const std::string& eventName,
-                                                                const eckit::LocalConfiguration& config) {
-    auto it = registry.find(eventName);
-    ASSERT_MSG(it != registry.end(), "Event '" + eventName + "' is not in the registry, please fix or remove.");
-    return it->second(config);
+std::unique_ptr<ExtremeEvent> ExtremeEventRegistry::createEvent(const eckit::LocalConfiguration& config,
+                                                                plume::data::ModelData& modelData,
+                                                                const std::vector<int>& coarseMapping) {
+    auto it = registry.find(config.getString("name"));
+    ASSERT_MSG(it != registry.end(),
+               "Event '" + config.getString("name") + "' is not in the registry, please fix or remove.");
+    return it->second(config, modelData, coarseMapping);
 }
 
 ExtremeEventRegistry& ExtremeEventRegistry::instance() {

--- a/src/ee_registry/ee_registry.h
+++ b/src/ee_registry/ee_registry.h
@@ -12,6 +12,7 @@
 #include <string>
 
 #include "eckit/config/LocalConfiguration.h"
+#include "plume/data/ModelData.h"
 
 #include "ee_base.h"
 
@@ -22,22 +23,24 @@
  */
 class ExtremeEventRegistry {
 public:
-    using ExtremeEventFactory = std::function<std::unique_ptr<ExtremeEvent>(const eckit::LocalConfiguration& config)>;
+    using ExtremeEventFactory = std::function<std::unique_ptr<ExtremeEvent>(
+        const eckit::LocalConfiguration& config, plume::data::ModelData&, const std::vector<int>& coarseMapping)>;
 
     void registerEvent(const std::string& eventName, ExtremeEventFactory factory);
-    std::unique_ptr<ExtremeEvent> createEvent(const std::string& eventName,
-                                                        const eckit::LocalConfiguration& config);
+    std::unique_ptr<ExtremeEvent> createEvent(const eckit::LocalConfiguration& config,
+                                              plume::data::ModelData& modelData, const std::vector<int>& coarseMapping);
     static ExtremeEventRegistry& instance();
 
-    ExtremeEventRegistry() = default;
     /// Singletons should not be cloneable.
     ExtremeEventRegistry(const ExtremeEventRegistry&) = delete;
     /// Singletons should not be assignable.
     ExtremeEventRegistry& operator=(const ExtremeEventRegistry&) = delete;
     /// Explicitly delete the moving operations.
-    ExtremeEventRegistry(ExtremeEventRegistry&&) = delete;
+    ExtremeEventRegistry(ExtremeEventRegistry&&)            = delete;
     ExtremeEventRegistry& operator=(ExtremeEventRegistry&&) = delete;
 
 private:
+    ExtremeEventRegistry() = default;
+
     std::map<std::string, ExtremeEventFactory> registry;
 };

--- a/src/ee_registry/extreme_wind.h
+++ b/src/ee_registry/extreme_wind.h
@@ -41,6 +41,7 @@ private:
     };
 
     std::vector<Interval> intervals_;
+    const std::vector<int>& coarseMapping_;
 
 public:
     /**
@@ -50,10 +51,13 @@ public:
      * the use of either the surface fields {10,100}{u,v} or the leveled fields {u,v}.
      * @warning Detection at given heights when levels are provided is not supported yet.
      *
-     * @param The configuration of the event, mainly consisting of parameters for bounds, description, and height
+     * @param config The configuration of the event, mainly consisting of parameters for bounds, description, and height
      *        for several instances.
+     * @param modelData The model data passed through Plume.
+     * @param coarseMapping The mapping to use to coarsen the detection data.
      */
-    ExtremeWind(const eckit::LocalConfiguration& config);
+    ExtremeWind(const eckit::LocalConfiguration& config, plume::data::ModelData& modelData,
+                const std::vector<int>& coarseMapping);
 
     /**
      * @brief Detects extreme winds at a given time step.
@@ -70,7 +74,10 @@ public:
     static struct Registrar {
         Registrar() {
             ExtremeEventRegistry::instance().registerEvent(
-                type_, [](const eckit::LocalConfiguration& config) { return std::make_unique<ExtremeWind>(config); });
+                type_, [](const eckit::LocalConfiguration& config, plume::data::ModelData& modelData,
+                          const std::vector<int>& coarseMapping) {
+                    return std::make_unique<ExtremeWind>(config, modelData, coarseMapping);
+                });
         }
     } registrar;
 };

--- a/src/ee_registry/storm.cc
+++ b/src/ee_registry/storm.cc
@@ -12,6 +12,7 @@
 #include <cmath>
 #include <cstring>
 #include <iostream>
+#include <limits>
 #include <unordered_map>
 
 #include "atlas/array.h"
@@ -32,14 +33,17 @@ Storm::Storm(const eckit::LocalConfiguration& config, plume::data::ModelData& mo
     if (requiredFields_ != std::vector<std::string>{"100u", "100v"}) {
         throw eckit::BadValue("Storm requires 100m wind component fields.", Here());
     }
-    windSpeedCutout_ = static_cast<FIELD_TYPE_REAL>(config.getDouble("wind_speed_cutout"));
-    if (windSpeedCutout_ < 0) {
-        throw eckit::BadValue("The cutout wind speed for the storm event should be positive", Here());
+    double windSpeedCutout = config.getDouble("wind_speed_cutout");
+    if (windSpeedCutout < 0 || windSpeedCutout > (std::numeric_limits<uint16_t>::max() / 100)) {
+        throw eckit::BadValue("The cutout wind speed for the storm event should be between 0 and " +
+                                  std::to_string(std::numeric_limits<uint16_t>::max() / 100),
+                              Here());
     }
 
+    windSpeedCutout_ = static_cast<uint16_t>(std::round(windSpeedCutout * 100));
     timeWindow_      = config.getUnsigned("time_window");
     ntimeSteps_      = std::ceil(timeWindow_ * 60 / modelData.getDouble("TSTEP"));
-    windSpeeds_      = std::deque<FIELD_TYPE_REAL>(ntimeSteps_ * coarseMapping_.size(), 0);
+    windSpeeds_      = std::deque<uint16_t>(ntimeSteps_ * coarseMapping_.size(), 0);
     description_     = "Storm (100m wind speed average over " + config.getString("time_window") + "min exceeding " +
                    config.getString("wind_speed_cutout") + "m/s)";
 }
@@ -52,7 +56,8 @@ std::vector<ExtremeEvent::DetectionData> Storm::detect(plume::data::ModelData& m
     windSpeeds_.erase(windSpeeds_.begin() + (ntimeSteps_ - 1) * coarseMapping_.size(), windSpeeds_.end());
     // reverse inserting element to maintain indices
     for (atlas::idx_t idx = coarseMapping_.size() - 1; idx >= 0; idx--) {
-        windSpeeds_.push_front(std::sqrt(fieldU(idx, 0) * fieldU(idx, 0) + fieldV(idx, 0) * fieldV(idx, 0)));
+        FIELD_TYPE_REAL windMagnitude = std::sqrt(fieldU(idx, 0) * fieldU(idx, 0) + fieldV(idx, 0) * fieldV(idx, 0));
+        windSpeeds_.push_front(static_cast<uint16_t>(std::round(windMagnitude * 100.0)));
     }
     
     if (modelData.getInt("NSTEP") < ntimeSteps_) {  // Fill the wind speed array but do not run detection yet
@@ -60,13 +65,12 @@ std::vector<ExtremeEvent::DetectionData> Storm::detect(plume::data::ModelData& m
     }
 
     // 2. Compute temporal average and run detection on the time window
-    std::unordered_map<int, FIELD_TYPE_REAL> cellMaximums;
+    std::unordered_map<int, uint32_t> cellMaximums;
     for (atlas::idx_t idx = 0; idx < coarseMapping_.size(); idx++) {
-        FIELD_TYPE_REAL windAvg = 0;
+        uint32_t windAvg = 0;
         for (size_t tstep = 0; tstep < ntimeSteps_; tstep++) {
             windAvg += windSpeeds_[tstep * coarseMapping_.size() + idx];
         }
-        windAvg /= ntimeSteps_;
         if (cellMaximums.find(coarseMapping_[idx]) == cellMaximums.end()) {
             cellMaximums[coarseMapping_[idx]] = windAvg;
         }
@@ -80,7 +84,7 @@ std::vector<ExtremeEvent::DetectionData> Storm::detect(plume::data::ModelData& m
      */
     ee_points.push_back({{}, description_, "100u/100v", "sfc", "0"});
     for (const auto& [cell, max] : cellMaximums) {
-        if (max > windSpeedCutout_) {
+        if (max > windSpeedCutout_ * ntimeSteps_) {
             ee_points[0].detectedCells.insert(cell);
         }
     }

--- a/src/ee_registry/storm.cc
+++ b/src/ee_registry/storm.cc
@@ -12,7 +12,6 @@
 #include <cmath>
 #include <cstring>
 #include <iostream>
-#include <limits>
 #include <unordered_map>
 
 #include "atlas/array.h"
@@ -33,17 +32,14 @@ Storm::Storm(const eckit::LocalConfiguration& config, plume::data::ModelData& mo
     if (requiredFields_ != std::vector<std::string>{"100u", "100v"}) {
         throw eckit::BadValue("Storm requires 100m wind component fields.", Here());
     }
-    double windSpeedCutout = config.getDouble("wind_speed_cutout");
-    if (windSpeedCutout < 0 || windSpeedCutout > (std::numeric_limits<uint16_t>::max() / 100)) {
-        throw eckit::BadValue("The cutout wind speed for the storm event should be between 0 and " +
-                                  std::to_string(std::numeric_limits<uint16_t>::max() / 100),
-                              Here());
+    windSpeedCutout_ = static_cast<FIELD_TYPE_REAL>(config.getDouble("wind_speed_cutout"));
+    if (windSpeedCutout_ < 0) {
+        throw eckit::BadValue("The cutout wind speed for the storm event should be positive", Here());
     }
 
-    windSpeedCutout_ = static_cast<uint16_t>(std::round(windSpeedCutout * 100));
     timeWindow_      = config.getUnsigned("time_window");
     ntimeSteps_      = std::ceil(timeWindow_ * 60 / modelData.getDouble("TSTEP"));
-    windSpeeds_      = std::deque<uint16_t>(ntimeSteps_ * coarseMapping_.size(), 0);
+    windSpeeds_      = std::deque<FIELD_TYPE_REAL>(ntimeSteps_ * coarseMapping_.size(), 0);
     description_     = "Storm (100m wind speed average over " + config.getString("time_window") + "min exceeding " +
                    config.getString("wind_speed_cutout") + "m/s)";
 }
@@ -56,8 +52,7 @@ std::vector<ExtremeEvent::DetectionData> Storm::detect(plume::data::ModelData& m
     windSpeeds_.erase(windSpeeds_.begin() + (ntimeSteps_ - 1) * coarseMapping_.size(), windSpeeds_.end());
     // reverse inserting element to maintain indices
     for (atlas::idx_t idx = coarseMapping_.size() - 1; idx >= 0; idx--) {
-        FIELD_TYPE_REAL windMagnitude = std::sqrt(fieldU(idx, 0) * fieldU(idx, 0) + fieldV(idx, 0) * fieldV(idx, 0));
-        windSpeeds_.push_front(static_cast<uint16_t>(std::round(windMagnitude * 100.0)));
+        windSpeeds_.push_front(std::sqrt(fieldU(idx, 0) * fieldU(idx, 0) + fieldV(idx, 0) * fieldV(idx, 0)));
     }
     
     if (modelData.getInt("NSTEP") < ntimeSteps_) {  // Fill the wind speed array but do not run detection yet
@@ -65,12 +60,13 @@ std::vector<ExtremeEvent::DetectionData> Storm::detect(plume::data::ModelData& m
     }
 
     // 2. Compute temporal average and run detection on the time window
-    std::unordered_map<int, uint32_t> cellMaximums;
+    std::unordered_map<int, FIELD_TYPE_REAL> cellMaximums;
     for (atlas::idx_t idx = 0; idx < coarseMapping_.size(); idx++) {
-        uint32_t windAvg = 0;
+        FIELD_TYPE_REAL windAvg = 0;
         for (size_t tstep = 0; tstep < ntimeSteps_; tstep++) {
             windAvg += windSpeeds_[tstep * coarseMapping_.size() + idx];
         }
+        windAvg /= ntimeSteps_;
         if (cellMaximums.find(coarseMapping_[idx]) == cellMaximums.end()) {
             cellMaximums[coarseMapping_[idx]] = windAvg;
         }
@@ -84,7 +80,7 @@ std::vector<ExtremeEvent::DetectionData> Storm::detect(plume::data::ModelData& m
      */
     ee_points.push_back({{}, description_, "100u/100v", "sfc", "0"});
     for (const auto& [cell, max] : cellMaximums) {
-        if (max > windSpeedCutout_ * ntimeSteps_) {
+        if (max > windSpeedCutout_) {
             ee_points[0].detectedCells.insert(cell);
         }
     }

--- a/src/ee_registry/storm.cc
+++ b/src/ee_registry/storm.cc
@@ -1,0 +1,91 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <iostream>
+#include <unordered_map>
+
+#include "atlas/array.h"
+#include "eckit/exception/Exceptions.h"
+
+#include "storm.h"
+
+const std::string Storm::type_ = "storm";
+
+Storm::Storm(const eckit::LocalConfiguration& config, plume::data::ModelData& modelData,
+             const std::vector<int>& coarseMapping) :
+    ExtremeEvent(config, type_), coarseMapping_(coarseMapping) {
+    std::sort(requiredFields_.begin(), requiredFields_.end());
+    /** @todo 100u and 100v will not exist after the GRIB2 migration, the event will need a refactor with an updated
+     *        Plume interface to access levtype 'hl' and level '100', or it can use the levtype 'ml' and compute the
+     *        height from the geopotential.
+     */
+    if (requiredFields_ != std::vector<std::string>{"100u", "100v"}) {
+        throw eckit::BadValue("Storm requires 100m wind component fields.", Here());
+    }
+    windSpeedCutout_ = static_cast<FIELD_TYPE_REAL>(config.getDouble("wind_speed_cutout"));
+    if (windSpeedCutout_ < 0) {
+        throw eckit::BadValue("The cutout wind speed for the storm event should be positive", Here());
+    }
+
+    timeWindow_      = config.getUnsigned("time_window");
+    ntimeSteps_      = std::ceil(timeWindow_ * 60 / modelData.getDouble("TSTEP"));
+    windSpeeds_      = std::deque<FIELD_TYPE_REAL>(ntimeSteps_ * coarseMapping_.size(), 0);
+    description_     = "Storm (100m wind speed average over " + config.getString("time_window") + "min exceeding " +
+                   config.getString("wind_speed_cutout") + "m/s)";
+}
+
+std::vector<ExtremeEvent::DetectionData> Storm::detect(plume::data::ModelData& modelData) {
+    std::vector<DetectionData> ee_points;
+    auto fieldU = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getAtlasFieldShared("100u"));
+    auto fieldV = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getAtlasFieldShared("100v"));
+    // 1. Slide the wind speeds window with current time step values
+    windSpeeds_.erase(windSpeeds_.begin() + (ntimeSteps_ - 1) * coarseMapping_.size(), windSpeeds_.end());
+    // reverse inserting element to maintain indices
+    for (atlas::idx_t idx = coarseMapping_.size() - 1; idx >= 0; idx--) {
+        windSpeeds_.push_front(std::sqrt(fieldU(idx, 0) * fieldU(idx, 0) + fieldV(idx, 0) * fieldV(idx, 0)));
+    }
+    
+    if (modelData.getInt("NSTEP") < ntimeSteps_) {  // Fill the wind speed array but do not run detection yet
+        return ee_points;
+    }
+
+    // 2. Compute temporal average and run detection on the time window
+    std::unordered_map<int, FIELD_TYPE_REAL> cellMaximums;
+    for (atlas::idx_t idx = 0; idx < coarseMapping_.size(); idx++) {
+        FIELD_TYPE_REAL windAvg = 0;
+        for (size_t tstep = 0; tstep < ntimeSteps_; tstep++) {
+            windAvg += windSpeeds_[tstep * coarseMapping_.size() + idx];
+        }
+        windAvg /= ntimeSteps_;
+        if (cellMaximums.find(coarseMapping_[idx]) == cellMaximums.end()) {
+            cellMaximums[coarseMapping_[idx]] = windAvg;
+        }
+        else {
+            cellMaximums[coarseMapping_[idx]] = std::max(cellMaximums[coarseMapping_[idx]], windAvg);
+        }
+    }
+
+    /** @todo Extremes DT output these fields as levtype 'hl' levelist '100', the keys will need an update for
+     *        GRIB2 compatibility. Ideally it is fetched from Plume or the field metadata instead of being hardcoded.
+     */
+    ee_points.push_back({{}, description_, "100u/100v", "sfc", "0"});
+    for (const auto& [cell, max] : cellMaximums) {
+        if (max > windSpeedCutout_) {
+            ee_points[0].detectedCells.insert(cell);
+        }
+    }
+
+    return ee_points;
+}
+
+Storm::Registrar Storm::registrar;

--- a/src/ee_registry/storm.h
+++ b/src/ee_registry/storm.h
@@ -1,0 +1,86 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <string>
+
+#include "eckit/config/LocalConfiguration.h"
+#include "plume/data/ModelData.h"
+
+#include "ee_registry.h"
+
+/**
+ * @class Storm
+ * @brief This event represents storm from wind components over a time window.
+ *
+ * See README for configuration guidelines.
+ */
+class Storm final : public ExtremeEvent {
+private:
+    static const std::string type_;
+    std::string description_;
+
+    unsigned int timeWindow_;
+    size_t ntimeSteps_;
+
+    FIELD_TYPE_REAL windSpeedCutout_;
+    /**
+     * This array stores the wind speeds of the original grid points.
+     * Time steps have contiguous indices: `{W_i,t, W_j,t, W_i,t-1, W_j,t-1...}`.
+     * This allows to easily slide the values for entire time steps.
+     */
+    std::deque<FIELD_TYPE_REAL> windSpeeds_;
+
+    const std::vector<int>& coarseMapping_;  ///< Reference to the points to cells mapping
+
+
+public:
+    /**
+     * @brief Constructs a storm event.
+     * 
+     * This event stores the wind speed for a certain number of time steps as its detection is based on temporal trends.
+     * The values are stored as doubles or floats to maintain the full precision, but there is a commit with a version
+     * of this event using 2-byte integers, as the wind can safely be represented on uint16_t if only two decimals of
+     * precision are kept.
+     * @warning Only GRIB1 fields 100u and 100v are used in this event for now. It will be migrated to GRIB2 later on.
+     *
+     * @param config The configuration of the event, mainly consisting of parameters for cutout speed and time window.
+     * @param modelData The model data passed through Plume.
+     * @param coarseMapping The mapping to use to coarsen the detection data.
+     */
+    Storm(const eckit::LocalConfiguration& config, plume::data::ModelData& modelData,
+          const std::vector<int>& coarseMapping);
+
+    /**
+     * @brief Detects storms using the definition below.
+     *
+     * This event checks if the 100m wind speed exceeds a configured threshold over a configured time window.
+     * Each coarse cell value is the maximum value of the temporal average of its original grid points.
+     *
+     * @param modelData The model data that contains the wind fields to run detection on.
+     *
+     * @return The detection result.
+     *         n.b.: single element as the event allows to configure a single time window and wind speed cutout.
+     */
+    std::vector<ExtremeEvent::DetectionData> detect(plume::data::ModelData& modelData) override;
+
+    /// Register the storm event into the registry so it can be used in the plugin.
+    static struct Registrar {
+        Registrar() {
+            ExtremeEventRegistry::instance().registerEvent(
+                type_, [](const eckit::LocalConfiguration& config, plume::data::ModelData& modelData,
+                          const std::vector<int>& coarseMapping) {
+                    return std::make_unique<Storm>(config, modelData, coarseMapping);
+                });
+        }
+    } registrar;
+};

--- a/src/ee_registry/storm.h
+++ b/src/ee_registry/storm.h
@@ -32,13 +32,13 @@ private:
     unsigned int timeWindow_;
     size_t ntimeSteps_;
 
-    uint16_t windSpeedCutout_;
+    FIELD_TYPE_REAL windSpeedCutout_;
     /**
      * This array stores the wind speeds of the original grid points.
      * Time steps have contiguous indices: `{W_i,t, W_j,t, W_i,t-1, W_j,t-1...}`.
      * This allows to easily slide the values for entire time steps.
      */
-    std::deque<uint16_t> windSpeeds_;
+    std::deque<FIELD_TYPE_REAL> windSpeeds_;
 
     const std::vector<int>& coarseMapping_;  ///< Reference to the points to cells mapping
 
@@ -48,7 +48,9 @@ public:
      * @brief Constructs a storm event.
      * 
      * This event stores the wind speed for a certain number of time steps as its detection is based on temporal trends.
-     * The values are stored as 2-bytes integers to divide the memory requirements by 4, at the cost of more operations.
+     * The values are stored as doubles or floats to maintain the full precision, but there is a commit with a version
+     * of this event using 2-byte integers, as the wind can safely be represented on uint16_t if only two decimals of
+     * precision are kept.
      * @warning Only GRIB1 fields 100u and 100v are used in this event for now. It will be migrated to GRIB2 later on.
      *
      * @param config The configuration of the event, mainly consisting of parameters for cutout speed and time window.
@@ -63,14 +65,6 @@ public:
      *
      * This event checks if the 100m wind speed exceeds a configured threshold over a configured time window.
      * Each coarse cell value is the maximum value of the temporal average of its original grid points.
-     * This table compares the execution time of the detection averaged over 4 time steps:
-     * 
-     * | Grid                 | uint16_t   | FIELD_TYPE_REAL |
-     * |----------------------|------------|-----------------|
-     * | N80 (35,718 pts)     | 1.27352 ms | 1.28456 ms      |
-     * | N320 (542,080 pts)   | 13.2834 ms | 19.0801 ms      |
-     * | N640 (2,140,702 pts) | 56.5634 ms | 87.7041 ms      |
-     * |----------------------|------------|-----------------|
      *
      * @param modelData The model data that contains the wind fields to run detection on.
      *

--- a/src/ee_registry/storm.h
+++ b/src/ee_registry/storm.h
@@ -32,13 +32,13 @@ private:
     unsigned int timeWindow_;
     size_t ntimeSteps_;
 
-    FIELD_TYPE_REAL windSpeedCutout_;
+    uint16_t windSpeedCutout_;
     /**
      * This array stores the wind speeds of the original grid points.
      * Time steps have contiguous indices: `{W_i,t, W_j,t, W_i,t-1, W_j,t-1...}`.
      * This allows to easily slide the values for entire time steps.
      */
-    std::deque<FIELD_TYPE_REAL> windSpeeds_;
+    std::deque<uint16_t> windSpeeds_;
 
     const std::vector<int>& coarseMapping_;  ///< Reference to the points to cells mapping
 
@@ -48,9 +48,7 @@ public:
      * @brief Constructs a storm event.
      * 
      * This event stores the wind speed for a certain number of time steps as its detection is based on temporal trends.
-     * The values are stored as doubles or floats to maintain the full precision, but there is a commit with a version
-     * of this event using 2-byte integers, as the wind can safely be represented on uint16_t if only two decimals of
-     * precision are kept.
+     * The values are stored as 2-bytes integers to divide the memory requirements by 4, at the cost of more operations.
      * @warning Only GRIB1 fields 100u and 100v are used in this event for now. It will be migrated to GRIB2 later on.
      *
      * @param config The configuration of the event, mainly consisting of parameters for cutout speed and time window.
@@ -65,6 +63,14 @@ public:
      *
      * This event checks if the 100m wind speed exceeds a configured threshold over a configured time window.
      * Each coarse cell value is the maximum value of the temporal average of its original grid points.
+     * This table compares the execution time of the detection averaged over 4 time steps:
+     * 
+     * | Grid                 | uint16_t   | FIELD_TYPE_REAL |
+     * |----------------------|------------|-----------------|
+     * | N80 (35,718 pts)     | 1.27352 ms | 1.28456 ms      |
+     * | N320 (542,080 pts)   | 13.2834 ms | 19.0801 ms      |
+     * | N640 (2,140,702 pts) | 56.5634 ms | 87.7041 ms      |
+     * |----------------------|------------|-----------------|
      *
      * @param modelData The model data that contains the wind fields to run detection on.
      *

--- a/src/healpix_utils.cc
+++ b/src/healpix_utils.cc
@@ -87,19 +87,14 @@ void mapLonLatToHEALPixCell(int resolution, const atlas::FunctionSpace& modelFS,
     }
 }
 
-std::vector<std::vector<atlas::PointLonLat>> cellToPolygons(std::vector<int>& eeIndices, std::vector<int>& mapping,
+std::vector<std::vector<atlas::PointLonLat>> cellToPolygons(std::set<int>& eeCells,
                                                             std::vector<std::vector<atlas::PointLonLat>>& vertices) {
     std::vector<std::vector<atlas::PointLonLat>> ee_polygons;
-    // 1. Find HealPix cells from EE points indices
-    std::set<int> ee_cells;
-    for (const int& point_idx : eeIndices) {
-        ee_cells.insert(mapping[point_idx]);
-    }
-    // 2. separate contiguous events and remove inner vertices
+    // Separate contiguous events and remove inner vertices
     // TODO: edge case: a region with holes has been detected
     // currently will end up with two separate events: hole and borders
     std::map<std::pair<atlas::PointLonLat, atlas::PointLonLat>, int> count_edges;
-    for (const int& cell_idx : ee_cells) {
+    for (const int& cell_idx : eeCells) {
         for (size_t vidx = 0; vidx < vertices[cell_idx].size(); ++vidx) {
             // Add all cell edges, handles quads and pents pole elements
             std::pair<atlas::PointLonLat, atlas::PointLonLat> ee_edge = {

--- a/src/healpix_utils.h
+++ b/src/healpix_utils.h
@@ -15,11 +15,11 @@ namespace HEALPixUtils {
 
 /**
  * @brief Creates a mapping of grid points from a given function space to the HEALPix cell they belong to.
- * 
+ *
  * This mapping can then be used to represent an extreme event region coarser than the model resolution.
  * If grid point `i` fires, `k = mappingVector[i]` is the index of the HEALPix cell it belongs to, and
  * `cellVertices[k]` is the vertices of that cell, which can be used to define a polygon on the globe.
- * 
+ *
  * @param[in] resolution The HEALPix resolution to use for the HEALPix mesh.
  * @param[in] modelFS The function space to map to HEALPix cells.
  * @param[out] mappingVector The vector mapping grid point remote indices to global HEALPix cell indices.
@@ -29,22 +29,21 @@ void mapLonLatToHEALPixCell(int resolution, const atlas::FunctionSpace& modelFS,
                             std::vector<std::vector<atlas::PointLonLat>>& cellVertices);
 
 /**
- * @brief Extracts HEALPix polygons from given firing points.
- * 
+ * @brief Extracts HEALPix polygons from given firing HEALPix cells.
+ *
  * This extraction function uses a map of the edges of the cells to determine contigous events, remove inner edges
  * which are not on a polygon boundary, and traverse vertices in a counter clockwise manner to ensure points are
  * populated in an order that correctly defines a polygon.
- * 
- * @param eeIndices The indices of the firing points on the model function space.
- * @param mapping The grid point to HEALPix cell mapping vector.
+ *
+ * @param eeCells The indices of the firing HEALPix cells.
  * @param vertices The HEALPix cell to its vertices coordinates mapping vector.
- * 
+ *
  * @return A vector containing all the polygons extracted from the firing points.
- * 
+ *
  * @warning All edge cases are not handled: - polygons with holes (holes are misclassified as single events)
  *                                          - global HEALPix mesh firing (the event is discarded)
  */
-std::vector<std::vector<atlas::PointLonLat>> cellToPolygons(std::vector<int>& eeIndices, std::vector<int>& mapping,
+std::vector<std::vector<atlas::PointLonLat>> cellToPolygons(std::set<int>& eeCells,
                                                             std::vector<std::vector<atlas::PointLonLat>>& vertices);
 
 }  // namespace HEALPixUtils

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(EE_PLUGIN_TEST_FILES_H
     ../src/ee_registry/ee_base.h
     ../src/ee_registry/ee_registry.h
     ../src/ee_registry/extreme_wind.h
+    ../src/ee_registry/storm.h
     ../src/plugin_types.h
 )
 
@@ -18,6 +19,7 @@ set(EE_PLUGIN_TEST_FILES_CC
     ../src/ee_plugin.cc
     ../src/ee_registry/ee_registry.cc
     ../src/ee_registry/extreme_wind.cc
+    ../src/ee_registry/storm.cc
 )
 
 set(EE_PLUGIN_TEST_SOURCES

--- a/tests/data/emulator_config.yml
+++ b/tests/data/emulator_config.yml
@@ -1,5 +1,5 @@
 emulator:
-  n_steps: 2
+  n_steps: 5
   grid_identifier: "N80"
   vertical_levels: 5
   fields:
@@ -13,6 +13,9 @@ emulator:
       apply:
         vortex_rollup:
           time_variation: 1.1
+        step:
+          area: [71.5, -25, 34.5, 45]
+          value: 21.0
     u:
       apply:
         levels:

--- a/tests/data/plume_config.yml
+++ b/tests/data/plume_config.yml
@@ -11,11 +11,16 @@ plugins:
           type: "atlas_field"
         - name: "100v"
           type: "atlas_field"
+      - &storm
+        - name: "100u"
+          type: "atlas_field"
+        - name: "100v"
+          type: "atlas_field"
     core-config:
         aviso_url: "test"
         notify_endpoint: "/test"
         enable_notification: true
-        healpix_res: 32
+        healpix_res: 16
         events:
           - name: "extreme_wind"
             enabled: true
@@ -28,3 +33,8 @@ plugins:
               - lower_bound: 0.0
                 upper_bound: 0.5
                 description: "No wind"
+          - name: "storm"
+            enabled: true
+            required_params: *storm
+            wind_speed_cutout: 20.0
+            time_window: 60


### PR DESCRIPTION
This PR adds an event that requires to store data across several time steps. For memory efficiency, the coarsening is used to lower the storage requirements, and that data is not stored as the field data type (floats or doubles) but as 2 bytes integers. This is possible because wind speeds typically never exceed 200m/s, allowing a precision of two decimals mean that we need 20000 possible values and uint16_t has a limit of 65536. Storing as integers also allows more stable threshold comparison.

Here are some detection results on the forecast on the day of storm Christian:
![fc_storm_hp32_cutout15](https://github.com/user-attachments/assets/8bd60bbb-67c2-4961-8f83-4747f38a279d)
![fc_storm_hp32_cutout20](https://github.com/user-attachments/assets/122d2a85-6aa3-4459-b843-d76c4ccc7598)
