### PR TITLE
PLUME-16: Add Wind Drought event

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,7 @@ set(EE_PLUGIN_FILES_H
     ee_registry/extreme_wind.h
     ee_registry/storm.h
     ee_registry/extreme_wave.h
+    ee_registry/wind_drought.h
     plugin_types.h
 )
 
@@ -46,6 +47,7 @@ set(EE_PLUGIN_FILES_CC
     ee_registry/extreme_wind.cc
     ee_registry/storm.cc
     ee_registry/extreme_wave.cc
+    ee_registry/wind_drought.cc
 )
 
 set(EE_PLUGIN_SOURCES

--- a/src/ee_registry/README.md
+++ b/src/ee_registry/README.md
@@ -8,9 +8,10 @@ extreme event plugin configuration. Anchors can be used to avoid errors and dupl
 The `enabled` key is optional, it can be set to `false` to keep an event in the configuration but not run it in the plugin.
 This key is `true` by default if omitted.
 
-[Extreme wind](#extreme-wind)
-[Storm](#storm)
+- [Extreme wind](#extreme-wind)
+- [Storm](#storm)
 - [Extreme wave](#extreme-wave)
+- [Wind drought](#wind-drought)
 
 ## Extreme wind
 
@@ -154,4 +155,39 @@ instances:
     description: "Storm conditions"
   - threshold: 3.5
     description: "Unsafe offshore wind-farm operations"
+```
+
+## Wind drought
+
+### Description
+
+This event with name `wind_drought` corresponds to prolonged periods of no wind which can constitute an extreme event
+from the electricity grid perspective, especially if combined with important cloud cover.
+
+It stores for each grid point the number of time steps where the wind stayed below a given threshold. The counters
+reset whenever the wind (spatial average over the coarse cell) exceeds the threshold.
+
+> [!NOTE]
+> The initial implementation of this event makes use of the `100u` and `100v` fields from GRIB 1.
+It will be migrated to GRIB 2 to use `u` and `v` at height level `100` in the future.
+
+### Configuration examples
+
+Only `100u` and `100v` fields are allowed at the moment. The event requires only two options:
+- The wind speed threshold: expressed in m/s.
+- The time window: expressed in minutes. The typical order of magnitude for the time window for this event is hours or
+  days, but they must be converted to minutes.
+
+```yaml
+parameters:
+  - &wind_drought
+    - name: "100u"
+      type: "atlas_field"
+    - name: "100v"
+      type: "atlas_field"
+...
+name: "wind_drought"
+required_params: *wind_drought
+wind_speed_cutout: 2.0
+time_window: 1440
 ```

--- a/src/ee_registry/wind_drought.cc
+++ b/src/ee_registry/wind_drought.cc
@@ -1,0 +1,76 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <cmath>
+
+#include "atlas/functionspace.h"
+#include "eckit/exception/Exceptions.h"
+
+#include "wind_drought.h"
+
+const std::string WindDrought::type_ = "wind_drought";
+
+WindDrought::WindDrought(const eckit::LocalConfiguration& config, plume::data::ModelData& modelData,
+                         const std::vector<int>& coarseMapping) :
+    ExtremeEvent(config, type_), coarseMapping_(coarseMapping) {
+    std::sort(requiredFields_.begin(), requiredFields_.end());
+    /** @todo 100u and 100v will not exist after the GRIB2 migration, the event will need a refactor with an updated
+     *        Plume interface to access levtype 'hl' and level '100', or it can use the levtype 'ml' and compute the
+     *        height from the geopotential.
+     */
+    if (requiredFields_ != std::vector<std::string>{"100u", "100v"}) {
+        throw eckit::BadValue("Wind drought event requires 100m wind component fields.", Here());
+    }
+    windSpeedCutout_ = static_cast<FIELD_TYPE_REAL>(config.getDouble("wind_speed_cutout"));
+    if (windSpeedCutout_ < 0) {
+        throw eckit::BadValue("The cutout wind magnitude for the wind drought event should be greater than 0", Here());
+    }
+
+    windDroughtSteps_.assign(coarseMapping_.size(), 0);
+    timeWindow_  = config.getUnsigned("time_window");
+    ntimeSteps_  = std::ceil(timeWindow_ * 60 / modelData.getDouble("TSTEP"));
+    description_ = "Wind drought (100m wind speed remains below " + config.getString("wind_speed_cutout") +
+                   "m/s for over " + config.getString("time_window") + "minutes)";
+}
+
+std::vector<ExtremeEvent::DetectionData> WindDrought::detect(plume::data::ModelData& modelData) {
+    std::vector<DetectionData> ee_points;
+    auto fieldU = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getAtlasFieldShared("100u"));
+    auto fieldV = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getAtlasFieldShared("100v"));
+    auto halo = atlas::array::make_view<int, 1>(modelData.getAtlasFieldShared("100u").functionspace().ghost());
+    // 1. Compute spatial wind speed average & update count for each cell
+    for (atlas::idx_t idx = 0; idx < coarseMapping_.size(); idx++) {
+        if (halo(idx) > 0) {
+            continue; // Halo counters stay at 0 so they have no effect
+        }
+
+        FIELD_TYPE_REAL windMagnitude = std::sqrt(fieldU(idx, 0) * fieldU(idx, 0) + fieldV(idx, 0) * fieldV(idx, 0));
+        if (windMagnitude < windSpeedCutout_) {
+            ++windDroughtSteps_[idx];
+        }
+        else {
+            windDroughtSteps_[idx] = 0; // This resets the counter if the wind finally exceeds the threshold
+        }
+    }
+
+    // 2. Detect the cells that have not exceeded the wind threshold during the time window
+    /** @todo Extremes DT output these fields as levtype 'hl' levelist '100', the keys will need an update for
+     *        GRIB2 compatibility. Ideally it is fetched from Plume or the field metadata instead of being hardcoded.
+     */
+    ee_points.push_back({{}, description_, "100u/100v", "sfc", "0"});
+    for (atlas::idx_t idx = 0; idx < coarseMapping_.size(); idx++) {
+        if (ntimeSteps_ < windDroughtSteps_[idx]) {
+            ee_points[0].detectedCells.insert(coarseMapping_[idx]);
+        }
+    }
+    return ee_points;
+}
+
+WindDrought::Registrar WindDrought::registrar;

--- a/src/ee_registry/wind_drought.h
+++ b/src/ee_registry/wind_drought.h
@@ -1,0 +1,80 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "eckit/config/LocalConfiguration.h"
+#include "plume/data/ModelData.h"
+
+#include "ee_registry.h"
+
+/**
+ * @class WindDrought
+ * @brief This event represents wind drought (long period of no wind) from wind components averaged over a time window.
+ *
+ * See README for configuration guidelines.
+ */
+class WindDrought final : public ExtremeEvent {
+private:
+    static const std::string type_;
+    std::string description_;
+
+    unsigned int timeWindow_;
+    uint16_t ntimeSteps_;
+
+    FIELD_TYPE_REAL windSpeedCutout_;
+    
+    /// This map stores the number of time steps with low wind speed over each grid point.
+    std::vector<unsigned int> windDroughtSteps_;
+    const std::vector<int>& coarseMapping_;  ///< Reference to the points to cells mapping to compute spatial averages
+
+
+public:
+    /**
+     * @brief Constructs a wind drought event (or prolonged period of no wind event).
+     *
+     * This event does not need to store wind values across steps because it is not computing a temporal average.
+     * It stores only a counter of the number of time steps below the threshold, which it compares to the number of
+     * time steps required to trigger the detection.
+     *
+     * @param config The configuration of the event, mainly consisting of parameters for cutout speed and time window.
+     * @param modelData The model data passed through Plume.
+     * @param coarseMapping The mapping to use to coarsen the detection data.
+     */
+    WindDrought(const eckit::LocalConfiguration& config, plume::data::ModelData& modelData,
+                const std::vector<int>& coarseMapping);
+
+    /**
+     * @brief Detects wind droughts using the definition below.
+     *
+     * This event checks if the 100m wind speed for each grid point remains under a given threshold for a configured
+     * time window. If it does, the coarse cell is marked as detected.
+     *
+     * @param modelData The model data that contains the wind fields to run detection on.
+     *
+     * @return The detection result.
+     *         n.b.: single element as the event allows to configure a single time window and wind speed cutout.
+     */
+    std::vector<ExtremeEvent::DetectionData> detect(plume::data::ModelData& modelData) override;
+
+    /// Register the wind drought event into the registry so it can be used in the plugin.
+    static struct Registrar {
+        Registrar() {
+            ExtremeEventRegistry::instance().registerEvent(
+                type_, [](const eckit::LocalConfiguration& config, plume::data::ModelData& modelData,
+                          const std::vector<int>& coarseMapping) {
+                    return std::make_unique<WindDrought>(config, modelData, coarseMapping);
+                });
+        }
+    } registrar;
+};

--- a/tests/data/emulator_config.yml
+++ b/tests/data/emulator_config.yml
@@ -6,8 +6,9 @@ emulator:
     100u:
       levtype: "sfc"
       apply:
-        vortex_rollup:
-          time_variation: 1.1
+        step:
+          value: 10.0
+          variation: -2.5
     100v:
       levtype: "sfc"
       apply:
@@ -15,18 +16,27 @@ emulator:
           time_variation: 1.1
         step:
           area: [71.5, -25, 34.5, 45]
-          value: 21.0
+          value: 30.0
+          variation: -7.5
     u:
       apply:
         levels:
           "1":
+            random:
+              min: 1.0
+              max: 5.0
             step:
               area: [71.5, -25, 34.5, 45] # rectangle represented by NW and SE (lat,lon) coordinates
-              value: 30.0
+              value: 0.0
+              variation: 0.12
           "2":
+            random:
+              min: 1.0
+              max: 5.0
             step:
               area: [-10, 113, -43.7, 155.3]
-              value: 30.0
+              value: 0.0
+              variation: 0.12
     v: "u"
     swh:
       levtype: "sfc"

--- a/tests/data/plume_config.yml
+++ b/tests/data/plume_config.yml
@@ -11,7 +11,7 @@ plugins:
           type: "atlas_field"
         - name: "100v"
           type: "atlas_field"
-      - &storm
+      - &100m_wind
         - name: "100u"
           type: "atlas_field"
         - name: "100v"
@@ -31,14 +31,14 @@ plugins:
             instances:
               - lower_bound: 25.0
                 upper_bound: 0.0
-                model_levels: [1, 2]
                 description: "Extremely strong wind"
               - lower_bound: 0.0
                 upper_bound: 0.5
+                model_levels: [1, 2]
                 description: "No wind"
           - name: "storm"
             enabled: true
-            required_params: *storm
+            required_params: *100m_wind
             wind_speed_cutout: 20.0
             time_window: 60
           - name: "extreme_wave"
@@ -49,3 +49,8 @@ plugins:
                 description: "Storm conditions"
               - threshold: 3.5
                 description: "Unsafe offshore wind-farm operations"
+          - name: "wind_drought"
+            enabled: true
+            required_params: *100m_wind
+            wind_speed_cutout: 2.0
+            time_window: 15


### PR DESCRIPTION
Similarly to the storm PR, this PR adds a wind drought event which has a lot of common points except that it does not need to store wind values for several steps directly but can store instead a counter of the number of time the threshold was not exceeded. This counter is then what is compared against to determine the detection status of a cell.

Here are some detection results from forecast data for December 12 2024 when no wind blew over Europe for a full day (not very convincing because no cell has fired in this region even when increasing the HP res from 16 to 32 to 64):
![low_wind_h16](https://github.com/user-attachments/assets/64cf908f-467a-4ca4-8086-f3e60802d58c)
![low_wind_h32](https://github.com/user-attachments/assets/9cd5f5d9-d122-440f-a7e2-e97368f2c4a6)
![low_wind_h64](https://github.com/user-attachments/assets/7a6ab0d5-5df9-4c09-bf48-a61edaf313a1)

