### PR TITLE
PLUME-16: Add ramp (up & down) event

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,7 @@ set(EE_PLUGIN_FILES_H
     ee_registry/storm.h
     ee_registry/extreme_wave.h
     ee_registry/wind_drought.h
+    ee_registry/ramp.h
     plugin_types.h
 )
 
@@ -48,6 +49,7 @@ set(EE_PLUGIN_FILES_CC
     ee_registry/storm.cc
     ee_registry/extreme_wave.cc
     ee_registry/wind_drought.cc
+    ee_registry/ramp.cc
 )
 
 set(EE_PLUGIN_SOURCES

--- a/src/ee_registry/README.md
+++ b/src/ee_registry/README.md
@@ -12,6 +12,7 @@ This key is `true` by default if omitted.
 - [Storm](#storm)
 - [Extreme wave](#extreme-wave)
 - [Wind drought](#wind-drought)
+- [Ramp](#ramp)
 
 ## Extreme wind
 
@@ -190,4 +191,46 @@ name: "wind_drought"
 required_params: *wind_drought
 wind_speed_cutout: 2.0
 time_window: 1440
+```
+
+## Ramp
+
+### Description
+
+This event with name `ramp` detects if the gradient varies positiviely or negatively more than a given value.
+Detection is triggered when the gradient of the parameter(s) (1+ grid point in the coarse cell) exceeds a given threshold
+over a specified time window.
+
+This event stores the parameter(s) value for each grid point and each time step in the time window.
+In case multiple parameters are passed, their magnitude is computed as stored value. It lies with the user to ensure
+this quantity makes sense.
+
+### Configuration examples
+
+Any combination of fields is allowed so users must be careful when configuring. The event allows several options:
+- The ramp thresholds: expressed in the same unit as the passed fields. There are two keys, one for ramp-ups and one
+  for ramp-downs. At least one should be present, they both should be positive values (the algorithm handles the sign).
+- The time window: expressed in minutes. If the time window is smaller than the internal model time step,
+the detection will run only on the current time step.
+
+```yaml
+parameters:
+  - &windRamp
+    - name: "100u"
+      type: "atlas_field"
+    - name: "100v"
+      type: "atlas_field"
+  - &temperatureRamp
+    - name: "2t"
+      type: "atlas_field"
+...
+- name: "ramp"
+  required_params: *windRamp
+  ramp_up_value: 10.0
+  ramp_down_value: 5.0
+  time_window: 30
+- name: "ramp"
+  required_params: *temperatureRamp
+  ramp_up_value: 10.0
+  time_window: 1440
 ```

--- a/src/ee_registry/ramp.cc
+++ b/src/ee_registry/ramp.cc
@@ -1,0 +1,135 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <algorithm>
+#include <cmath>
+#include <sstream>
+#include <unordered_map>
+
+#include "atlas/array.h"
+#include "atlas/functionspace.h"
+#include "eckit/exception/Exceptions.h"
+
+#include "ramp.h"
+
+const std::string RampEvent::type_ = "ramp";
+
+RampEvent::RampEvent(const eckit::LocalConfiguration& config, plume::data::ModelData& modelData,
+                     const std::vector<int>& coarseMapping) :
+    ExtremeEvent(config, type_), coarseMapping_(coarseMapping) {
+    if (config.has("ramp_up_value")) {
+        rampUpValue_ = static_cast<FIELD_TYPE_REAL>(config.getDouble("ramp_up_value"));
+        rampUp_      = true;
+    }
+    if (config.has("ramp_down_value")) {
+        rampDownValue_ = static_cast<FIELD_TYPE_REAL>(config.getDouble("ramp_down_value"));
+        rampDown_      = true;
+    }
+    if ((rampUp_ && rampUpValue_ < 1e-6) || (rampDown_ && rampDownValue_ < 1e-6) || (!rampUp_ && !rampDown_)) {
+        throw eckit::BadValue(
+            "The ramp values for the ramp event should be positive, and at least one of them should be provided",
+            Here());
+    }
+
+    timeWindow_     = config.getUnsigned("time_window");
+    ntimeSteps_     = std::ceil(timeWindow_ * 60 / modelData.getDouble("TSTEP"));
+    previousValues_ = std::deque<FIELD_TYPE_REAL>(ntimeSteps_ * coarseMapping_.size(), 0);
+
+    std::ostringstream fieldVec;
+    for (size_t i = 0; i < requiredFields_.size() - 1; i++) {
+        fieldVec << requiredFields_[i] << "/";
+    }
+    fieldVec << requiredFields_[requiredFields_.size() - 1];
+    fieldNamesStr_ = fieldVec.str();
+    if (rampUp_) {
+        descriptionUp_ = "Ramp up of " + config.getString("ramp_up_value") + " over " +
+                         config.getString("time_window") + "min for param(s) " + fieldNamesStr_;
+    }
+    if (rampDown_) {
+        descriptionDown_ = "Ramp down of " + config.getString("ramp_down_value") + " over " +
+                           config.getString("time_window") + "min for param(s) " + fieldNamesStr_;
+    }
+}
+
+std::vector<ExtremeEvent::DetectionData> RampEvent::detect(plume::data::ModelData& modelData) {
+    std::vector<DetectionData> ee_points;
+    std::vector<atlas::array::ArrayView<const FIELD_TYPE_REAL, 2>> fields;
+    for (const auto& field : requiredFields_) {
+        fields.push_back(atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getAtlasFieldShared(field)));
+    }
+    auto halo
+        = atlas::array::make_view<int, 1>(modelData.getAtlasFieldShared(requiredFields_[0]).functionspace().ghost());
+    // 1. Slide the values window with current time step values
+    previousValues_.erase(previousValues_.begin() + (ntimeSteps_ - 1) * coarseMapping_.size(), previousValues_.end());
+    // reverse inserting element to maintain indices
+    for (atlas::idx_t idx = coarseMapping_.size() - 1; idx >= 0; idx--) {
+        if (halo(idx) > 0) {
+            previousValues_.push_front(0); // Add values with no effect in the halo
+        }
+
+        // If several parameters are given, the magnitude is computed as the value, it is the user's responsibility
+        // to ensure this quantity makes sense, and the passed fields are 2D (or run detection on level 1)
+        if (fields.size() > 1) {
+            FIELD_TYPE_REAL squareMag = 0;
+            for (const auto& field : fields) {
+                squareMag += field(idx, 0) * field(idx, 0);
+            }
+            previousValues_.push_front(std::sqrt(squareMag));
+        }
+        else {
+            previousValues_.push_front(fields[0](idx, 0));
+        }
+    }    
+
+    if (modelData.getInt("NSTEP") < ntimeSteps_) {  // Fill the previous values array but do not run detection yet
+        return ee_points;
+    }
+
+    // 2. Compute temporal gradient and run detection on the time window
+    std::unordered_map<int, FIELD_TYPE_REAL> cellMaxima;
+    std::unordered_map<int, FIELD_TYPE_REAL> cellMinima;
+    for (atlas::idx_t idx = 0; idx < coarseMapping_.size(); idx++) {
+        FIELD_TYPE_REAL gradient =
+            previousValues_[idx] - previousValues_[idx + (ntimeSteps_ - 1) * coarseMapping_.size()];
+        if (rampUp_) {
+            if (cellMaxima.find(coarseMapping_[idx]) == cellMaxima.end()) {
+                cellMaxima[coarseMapping_[idx]] = gradient;
+            }
+            else {
+                cellMaxima[coarseMapping_[idx]] = std::max(cellMaxima[coarseMapping_[idx]], gradient);
+            }
+        }
+        if (rampDown_) {
+            if (cellMinima.find(coarseMapping_[idx]) == cellMinima.end()) {
+                cellMinima[coarseMapping_[idx]] = gradient;
+            }
+            else {
+                cellMinima[coarseMapping_[idx]] = std::min(cellMinima[coarseMapping_[idx]], gradient);
+            }
+        }
+    }
+
+    ee_points.push_back({{}, descriptionUp_, fieldNamesStr_, "sfc", "0"});
+    ee_points.push_back({{}, descriptionDown_, fieldNamesStr_, "sfc", "0"});
+    for (const auto& [cell, max] : cellMaxima) {
+        if (max > rampUpValue_) {
+            ee_points[0].detectedCells.insert(cell);
+        }
+    }
+    for (const auto& [cell, min] : cellMinima) {
+        if (min < -rampDownValue_) {
+            ee_points[1].detectedCells.insert(cell);
+        }
+    }
+
+    return ee_points;
+}
+
+RampEvent::Registrar RampEvent::registrar;

--- a/src/ee_registry/ramp.h
+++ b/src/ee_registry/ramp.h
@@ -1,0 +1,85 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <deque>
+#include <memory>
+#include <string>
+
+#include "eckit/config/LocalConfiguration.h"
+#include "plume/data/ModelData.h"
+
+#include "ee_registry.h"
+
+/**
+ * @class Ramp
+ * @brief This event represents ramp-ups or ramp-downs from given parameters over a time window.
+ *
+ * See README for configuration guidelines.
+ */
+class RampEvent final : public ExtremeEvent {
+private:
+    static const std::string type_;
+    std::string descriptionUp_;
+    std::string descriptionDown_;
+    std::string fieldNamesStr_;
+
+    unsigned int timeWindow_;
+    size_t ntimeSteps_;
+
+    FIELD_TYPE_REAL rampUpValue_;  ///< the units should match the params unit (user's responsibility)
+    FIELD_TYPE_REAL rampDownValue_;
+    bool rampUp_   = false;
+    bool rampDown_ = false;
+    /**
+     * This array stores the values of the original grid points from the previous time steps.
+     * Time steps have contiguous indices: `{W_i,t, W_j,t, W_i,t-1, W_j,t-1...}`.
+     * This allows to easily slide the values for entire time steps.
+     */
+    std::deque<FIELD_TYPE_REAL> previousValues_;
+
+    const std::vector<int>& coarseMapping_;  ///< Reference to the points to cells mapping
+
+
+public:
+    /**
+     * @brief Constructs a ramp event.
+     *
+     * @param config The configuration of the event, mainly consisting of parameters for ramp values and time window.
+     * @param modelData The model data passed through Plume.
+     * @param coarseMapping The mapping to use to coarsen the detection data.
+     */
+    RampEvent(const eckit::LocalConfiguration& config, plume::data::ModelData& modelData,
+              const std::vector<int>& coarseMapping);
+
+    /**
+     * @brief Detects ramp-ups or ramp-downs using the definition below.
+     *
+     * This event checks if the given parameter(s) gradient over a configured time window varies from a given threshold.
+     * The sign of the ramp can be configured if the event should detect only ups, or downs or both.
+     *
+     * @param modelData The model data that contains the fields to run detection on.
+     *
+     * @return The detection result.
+     *         n.b.: two elements as the event allows to configure a single set of params and threshold for up and down.
+     *               Multiple ramp events can be configured if detection is expected on various params.
+     */
+    std::vector<ExtremeEvent::DetectionData> detect(plume::data::ModelData& modelData) override;
+
+    /// Register the ramp event into the registry so it can be used in the plugin.
+    static struct Registrar {
+        Registrar() {
+            ExtremeEventRegistry::instance().registerEvent(
+                type_, [](const eckit::LocalConfiguration& config, plume::data::ModelData& modelData,
+                          const std::vector<int>& coarseMapping) {
+                    return std::make_unique<RampEvent>(config, modelData, coarseMapping);
+                });
+        }
+    } registrar;
+};

--- a/tests/data/emulator_config.yml
+++ b/tests/data/emulator_config.yml
@@ -18,6 +18,13 @@ emulator:
           area: [71.5, -25, 34.5, 45]
           value: 30.0
           variation: -7.5
+    2t:
+      levtype: "sfc"
+      apply:
+        step:
+          area: [71.5, -25, 34.5, 45]
+          value: 10.0
+          variation: 5.0
     u:
       apply:
         levels:

--- a/tests/data/plume_config.yml
+++ b/tests/data/plume_config.yml
@@ -19,6 +19,9 @@ plugins:
       - &waves
         - name: "swh"
           type: "atlas_field"
+      - &temperatureRamp
+        - name: "2t"
+          type: "atlas_field"
     core-config:
         aviso_url: "test"
         notify_endpoint: "/test"
@@ -54,3 +57,8 @@ plugins:
             required_params: *100m_wind
             wind_speed_cutout: 2.0
             time_window: 15
+          - name: "ramp"
+            enabled: true
+            required_params: *temperatureRamp
+            ramp_up_value: 10.0
+            time_window: 60


### PR DESCRIPTION
Similarly to the storm PR, this PR adds a ramp event which has a lot of common points except that instead of averaging the fields over time, it computes the difference on the time window to detect a ramp UP or DOWN or both. If a single grid point in a coarse cell has a gradient that exceeds the configured threshold, the cell fires.

Here are some detection results from forecast data for 2019-10-15 when significant wind ramp-ups happened over the North Sea, ramp-up that was successfully captured by the detection and the data used:
![map060m](https://github.com/user-attachments/assets/b4ad3112-23ff-4f65-8d1d-f26ec5c68d72)
