### PR TITLE
PLUME-31: Add extreme wave event

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ set(EE_PLUGIN_FILES_H
     ee_registry/ee_registry.h
     ee_registry/extreme_wind.h
     ee_registry/storm.h
+    ee_registry/extreme_wave.h
     plugin_types.h
 )
 
@@ -44,6 +45,7 @@ set(EE_PLUGIN_FILES_CC
     ee_registry/ee_registry.cc
     ee_registry/extreme_wind.cc
     ee_registry/storm.cc
+    ee_registry/extreme_wave.cc
 )
 
 set(EE_PLUGIN_SOURCES

--- a/src/ee_registry/README.md
+++ b/src/ee_registry/README.md
@@ -10,6 +10,7 @@ This key is `true` by default if omitted.
 
 [Extreme wind](#extreme-wind)
 [Storm](#storm)
+- [Extreme wave](#extreme-wave)
 
 ## Extreme wind
 
@@ -115,4 +116,42 @@ name: "storm"
 required_params: *storm
 wind_speed_cutout: 20.0
 time_window: 60
+```
+
+## Extreme wave
+
+### Description
+
+This event with name `extreme_wave` detects significant wave height of combined wind sea and swell above a specified
+threshold. It scans the 'swh' field, and flags the grid points that exceed the threshold(s). The same `extreme_wave`
+event can be used to detect several thresholds, via configuring the `instances` list key. Each element represents a 
+threhsold with its corresponding description (optional). For instance, a user can configure two thresholds: 3.5 meters
+which corresponds to the height after which operations on wind farms are no longer safe, and 8 meters which suggest
+stormy conditions.
+
+> [!NOTE]
+> It is assumed that the coarsening established by the plugin applies to wave fields and atmospheric fields, which is
+true if they are represented on the same grid, but false otherwise.
+
+### Configuration examples
+
+The configuration below corresponds to the example given in the description. The thresholds are expressed in meters.
+By default the missing value is set to 9999, but it can be changed from the configuration if the wave fields use a
+different value. It is important to handle the missing value correctly in the wave fields because land areas are
+represented by the missing value, and should not trigger the detection.
+
+```yaml
+parameters:
+  - &extreme_waves
+    - name: "swh"
+      type: "atlas_field"
+...
+name: "extreme_wave"
+required_params: *extreme_waves
+missing_value: -9999
+instances:
+  - threshold: 8.0
+    description: "Storm conditions"
+  - threshold: 3.5
+    description: "Unsafe offshore wind-farm operations"
 ```

--- a/src/ee_registry/extreme_wave.cc
+++ b/src/ee_registry/extreme_wave.cc
@@ -1,0 +1,89 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <sstream>
+
+#include "atlas/array.h"
+#include "atlas/field.h"
+#include "atlas/functionspace.h"
+#include "eckit/exception/Exceptions.h"
+
+#include "extreme_wave.h"
+
+const std::string ExtremeWave::type_ = "extreme_wave";
+
+ExtremeWave::ExtremeWave(const eckit::LocalConfiguration& config, plume::data::ModelData& modelData,
+                         const std::vector<int>& coarseMapping) :
+    ExtremeEvent(config, type_),
+    coarseMapping_(coarseMapping),
+    missingValue_(static_cast<FIELD_TYPE_REAL>(config.getInt("missing_value", 9999))) {
+    // Validate that the required field is swh
+    if (requiredFields_[0] != "swh" || requiredFields_.size() > 1) {
+        throw eckit::BadValue("The 'extreme_wave' event requires the significant wave height field", Here());
+    }
+
+    // Retrieve the thresholds to run detection on
+    for (const auto& instance : config.getSubConfigurations("instances")) {
+        if (instance.getDouble("threshold") < 1e-6) {
+            throw eckit::BadValue("Extreme wave thresholds must be positive", Here());
+        }
+        FIELD_TYPE_REAL value = static_cast<FIELD_TYPE_REAL>(instance.getDouble("threshold"));
+        std::ostringstream description;
+        description << "Extreme waves";
+        if (instance.has("description")) {
+            description << ": " << instance.getString("description");
+        }
+        description << " (swh > " << instance.getString("threshold") << "m)";
+
+        thresholds_.push_back({value, description.str()});
+    }
+
+    // Ensure there is at least one instance to run detection on
+    if (thresholds_.empty()) {
+        throw eckit::BadValue("No valid instance found for 'extreme_wave'", Here());
+    }
+
+    // Sort thresholds by decreasing values (as high thresholds should automatically trigger small thresholds)
+    std::sort(thresholds_.begin(), thresholds_.end(),
+              [](const Threshold& a, const Threshold& b) { return a.value > b.value; });
+}
+
+std::vector<ExtremeEvent::DetectionData> ExtremeWave::detect(plume::data::ModelData& modelData) {
+    std::vector<DetectionData> ee_points;
+    for (const auto& threshold : thresholds_) {
+        // Wave fields are 2D but level or levtype are not necessary to retrieve them
+        ee_points.push_back({{}, threshold.description, "swh", "", ""});
+    }
+
+    auto fieldSwh = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getAtlasFieldShared("swh"));
+    auto halo     = atlas::array::make_view<int, 1>(modelData.getAtlasFieldShared("swh").functionspace().ghost());
+    for (atlas::idx_t idx = 0; idx < coarseMapping_.size(); idx++) {
+        // Skip the halo and missing values (over land)
+        if (halo(idx) > 0 || fieldSwh(idx, 0) == missingValue_) {
+            continue;
+        }
+
+        bool higherThresholdFired = false;
+        for (size_t idx_thsld = 0; idx_thsld < thresholds_.size(); idx_thsld++) {
+            if (higherThresholdFired) {
+                ee_points[idx_thsld].detectedCells.insert(coarseMapping_[idx]);
+                continue;
+            }
+            if (fieldSwh(idx, 0) > thresholds_[idx_thsld].value) {
+                ee_points[idx_thsld].detectedCells.insert(coarseMapping_[idx]);
+                higherThresholdFired = true;
+            }
+        }
+    }
+
+    return ee_points;
+}
+
+ExtremeWave::Registrar ExtremeWave::registrar;

--- a/src/ee_registry/extreme_wave.h
+++ b/src/ee_registry/extreme_wave.h
@@ -1,0 +1,82 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <string>
+#include <vector>
+
+#include "eckit/config/LocalConfiguration.h"
+#include "plume/data/ModelData.h"
+
+#include "ee_registry.h"
+
+/**
+ * @class ExtremeWave
+ * @brief This event represents extreme waves at a given time step.
+ *
+ * The thresholds to use should be defined in the configuration. See README for configuration guidelines.
+ */
+class ExtremeWave final : public ExtremeEvent {
+private:
+    static const std::string type_;
+
+    const std::vector<int>& coarseMapping_;
+    const FIELD_TYPE_REAL missingValue_;
+
+    /**
+     * @brief Represents the wave thresholds to run detection on.
+     *
+     * A description can be provided for communicating results in a human-friendly fashion.
+     */
+    struct Threshold {
+        FIELD_TYPE_REAL value;
+        std::string description;
+    };
+
+    std::vector<Threshold> thresholds_;
+
+public:
+    /**
+     * @brief Constructs an extreme wave event.
+     *
+     * This event is using the same coarsening mapping as atmospheric-related events as it is assumed the wave fields
+     * are represented on the same grid.
+     *
+     * @param config The configuration of the event, more importantly the wave height thresholds and their description.
+     * @param modelData The model data passed through Plume.
+     * @param coarseMapping The mapping to use to coarsen the detection data.
+     */
+    ExtremeWave(const eckit::LocalConfiguration& config, plume::data::ModelData& modelData,
+                const std::vector<int>& coarseMapping);
+
+    /**
+     * @brief Detects extreme waves at a given time step.
+     *
+     * This event checks whether the significant wave height of combined wind waves and swell exceeds certain
+     * thresholds at a single time step. Several thresholds are allowed to represent different level of severity,
+     * e.g., there can be a threshold for safe offshore wind farm operations, and a threshold for wind turbine
+     * structural damage.
+     *
+     * @param modelData The model data that contains the wind fields to run detection on.
+     *
+     * @return The detection results for each threshold.
+     */
+    std::vector<ExtremeEvent::DetectionData> detect(plume::data::ModelData& modelData) override;
+
+    /// Register the extreme wave event into the registry so it can be used in the plugin.
+    static struct Registrar {
+        Registrar() {
+            ExtremeEventRegistry::instance().registerEvent(
+                type_, [](const eckit::LocalConfiguration& config, plume::data::ModelData& modelData,
+                          const std::vector<int>& coarseMapping) {
+                    return std::make_unique<ExtremeWave>(config, modelData, coarseMapping);
+                });
+        }
+    } registrar;
+};

--- a/src/ee_registry/storm.cc
+++ b/src/ee_registry/storm.cc
@@ -15,6 +15,8 @@
 #include <unordered_map>
 
 #include "atlas/array.h"
+#include "atlas/field.h"
+#include "atlas/functionspace.h"
 #include "eckit/exception/Exceptions.h"
 
 #include "storm.h"
@@ -48,11 +50,17 @@ std::vector<ExtremeEvent::DetectionData> Storm::detect(plume::data::ModelData& m
     std::vector<DetectionData> ee_points;
     auto fieldU = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getAtlasFieldShared("100u"));
     auto fieldV = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getAtlasFieldShared("100v"));
+    auto halo = atlas::array::make_view<int, 1>(modelData.getAtlasFieldShared("100u").functionspace().ghost());
     // 1. Slide the wind speeds window with current time step values
     windSpeeds_.erase(windSpeeds_.begin() + (ntimeSteps_ - 1) * coarseMapping_.size(), windSpeeds_.end());
     // reverse inserting element to maintain indices
     for (atlas::idx_t idx = coarseMapping_.size() - 1; idx >= 0; idx--) {
-        windSpeeds_.push_front(std::sqrt(fieldU(idx, 0) * fieldU(idx, 0) + fieldV(idx, 0) * fieldV(idx, 0)));
+        if (halo(idx) > 0) {
+            windSpeeds_.push_front(0); // Add values with no effect for halo points
+        }
+        else {
+            windSpeeds_.push_front(std::sqrt(fieldU(idx, 0) * fieldU(idx, 0) + fieldV(idx, 0) * fieldV(idx, 0)));
+        }
     }
     
     if (modelData.getInt("NSTEP") < ntimeSteps_) {  // Fill the wind speed array but do not run detection yet

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(EE_PLUGIN_TEST_FILES_H
     ../src/ee_registry/ee_registry.h
     ../src/ee_registry/extreme_wind.h
     ../src/ee_registry/storm.h
+    ../src/ee_registry/extreme_wave.h
     ../src/plugin_types.h
 )
 
@@ -20,6 +21,7 @@ set(EE_PLUGIN_TEST_FILES_CC
     ../src/ee_registry/ee_registry.cc
     ../src/ee_registry/extreme_wind.cc
     ../src/ee_registry/storm.cc
+    ../src/ee_registry/extreme_wave.cc
 )
 
 set(EE_PLUGIN_TEST_SOURCES

--- a/tests/data/emulator_config.yml
+++ b/tests/data/emulator_config.yml
@@ -28,3 +28,9 @@ emulator:
               area: [-10, 113, -43.7, 155.3]
               value: 30.0
     v: "u"
+    swh:
+      levtype: "sfc"
+      apply:
+        step:
+          area: [71.5, -25, 34.5, 45]
+          value: 4.0

--- a/tests/data/plume_config.yml
+++ b/tests/data/plume_config.yml
@@ -16,6 +16,9 @@ plugins:
           type: "atlas_field"
         - name: "100v"
           type: "atlas_field"
+      - &waves
+        - name: "swh"
+          type: "atlas_field"
     core-config:
         aviso_url: "test"
         notify_endpoint: "/test"
@@ -38,3 +41,11 @@ plugins:
             required_params: *storm
             wind_speed_cutout: 20.0
             time_window: 60
+          - name: "extreme_wave"
+            enabled: true
+            required_params: *waves
+            instances:
+              - threshold: 8.0
+                description: "Storm conditions"
+              - threshold: 3.5
+                description: "Unsafe offshore wind-farm operations"


### PR DESCRIPTION
This PR adds an extreme wave event to the registry. This event uses the significant wave height and triggers when it exceeds a given threshold. It supports defining several thresholds. Wave fields have missing values all over the land, so when configuring, the missing value must be correct or default, otherwise the detection will be wrong (e.g., fire all the lands in addition to actual regions of high waves).

Here is an example of running it with the Plume emulator on cyclone Tilo: high waves are correctly flagged over the North Sea.
![cyclone_tilo](https://github.com/user-attachments/assets/617d2908-db82-4b79-a7a0-fd70d164e01f)

Note: there is also a bugfix in this PR skipping halo points in the storm event to avoid double detection.