### PR TITLE
PLUME-37: Add event filtering based on run tag

### DIFF
--- a/src/ee_plugin.cc
+++ b/src/ee_plugin.cc
@@ -49,7 +49,8 @@ void EEPluginCore::setup() {
             }
         }
         if (hasRequiredParams) {
-            extremeEvents_.push_back(ExtremeEventRegistry::instance().createEvent(ee, modelData(), Point2HPcell_));
+            extremeEvents_[ee.getInt("run_with_model", -1)].push_back(
+                ExtremeEventRegistry::instance().createEvent(ee, modelData(), Point2HPcell_));
             eckit::Log::info() << ee.getString("name") << " ";
         }
     }
@@ -60,9 +61,36 @@ void EEPluginCore::setup() {
 }
 
 void EEPluginCore::run() {
-    // Determine the elapsed time in the simulation in minutes
-    std::string elapsedTime = modelStepStr();
-    for (auto& ee : extremeEvents_) {
+    if (extremeEvents_.find(-1) == extremeEvents_.end()) {
+        eckit::Log::warning() << "No extreme event loaded for generic caller, skip..." << std::endl;
+        return;
+    }
+    detect(-1);
+}
+
+void EEPluginCore::run(int caller) {
+    if (caller == -1) {
+        run();
+    }
+    else {
+        // Run the generic events but do not warn if there are none
+        if (extremeEvents_.find(-1) != extremeEvents_.end()) {
+            eckit::Log::info() << "Running generic extreme events as part of caller " << caller << std::endl;
+            detect(-1);
+        }
+        // Run the caller-specific events if there are any
+        if (extremeEvents_.find(caller) == extremeEvents_.end()) {
+            eckit::Log::warning() << "No extreme event loaded for caller " << caller << ", skip..." << std::endl;
+            return;
+        }
+        detect(caller);
+    }
+}
+
+void EEPluginCore::detect(int caller) {
+    for (auto& ee : extremeEvents_[caller]) {
+        // Determine the elapsed time in the simulation in minutes
+        std::string elapsedTime = modelStepStr(ee->simulatedSeconds(modelData()));
         // Run the detection for each extreme event suite
         auto results = ee->detect(modelData());
         for (size_t idx = 0; idx < results.size(); ++idx) {
@@ -99,11 +127,10 @@ void EEPluginCore::setHEALPixMapping() {
     mapLonLatToHEALPixCell(healpixRes_, fs, Point2HPcell_, HPcell2polygon_);
 }
 
-std::string EEPluginCore::modelStepStr() {
-    if (modelData().getInt("NSTEP") == 0) {
+std::string EEPluginCore::modelStepStr(int seconds) {
+    if (seconds == 0) {
         return "0s";
     }
-    int seconds = static_cast<int>(std::round(modelData().getInt("NSTEP") * modelData().getDouble("TSTEP")));
     // Sub-hourly supported time units (except for seconds)
     const std::vector<std::pair<int, std::string>> timeUnits = {{86400, "d"}, {3600, "h"}, {60, "m"}};
     for (const auto& unit : timeUnits) {
@@ -119,7 +146,7 @@ std::string EEPluginCore::modelStepStr() {
 
 // ------------------------------------------------------
 
-EEPlugin::EEPlugin() : Plugin("EEPlugin"){};
+EEPlugin::EEPlugin() : Plugin("EEPlugin") {};
 
 const EEPlugin& EEPlugin::instance() {
     static EEPlugin instance;

--- a/src/ee_plugin.h
+++ b/src/ee_plugin.h
@@ -8,6 +8,8 @@
  * granted to it by virtue of its status as an intergovernmental organisation nor
  * does it submit to any jurisdiction.
  */
+#include <map>
+
 #include "atlas/grid.h"
 #include "eckit/config/Configuration.h"
 #include "eckit/config/LocalConfiguration.h"
@@ -80,12 +82,25 @@ public:
      */
     void run() override;
 
+    /**
+     * @brief Runs the plugin with a filter based on the location of the call.
+     *
+     * The steps are the same as described above, except only the events matching the caller have their detection ran.
+     * The run of events with generic callers is always triggerred regardless of the tag.
+     * There is no guarantee that the configured caller for a subset of events will actually call the plugin at any
+     * point in the simulation. The plugin does not issue any particular warning in this situation, it is the user's
+     * responsibility to ensure the caller code configured is consistent with the model(s).
+     *
+     * @param caller The integer identifying the location in the simulation where the call was triggerred.
+     */
+    void run(int caller) override;
+
     /// Returns the plugin core type, for Plume usage.
     constexpr static const char* type() { return "ee-plugincore"; }
 
 private:
     std::vector<eckit::LocalConfiguration> extremeEventConfig_;
-    std::vector<std::unique_ptr<ExtremeEvent>>
+    std::map<int, std::vector<std::unique_ptr<ExtremeEvent>>>
         extremeEvents_;  ///< A single plugin manages all instances of different extreme events
 
     AvisoNotificationHandler notificationHandler_;
@@ -106,10 +121,18 @@ private:
     /**
      * @brief Returns the MARS value string representing the sub-hourly model step.
      *
+     * @param seconds The number of seconds elapsed in the simulation to turn into a string.
      * @warning It is important to note that this step is only internal, there is no guarantee that it will
      *          correspond to an actual output step. Data from this step may not be retrievable after the run.
      */
-    std::string modelStepStr();
+    std::string modelStepStr(int seconds);
+
+    /**
+     * @brief Runs steps 1, 2, 3 described in the run method.
+     *
+     * @param caller The filter value to get the events to run detection on.
+     */
+    void detect(int caller);
 };
 
 
@@ -135,6 +158,7 @@ public:
         protocol.requireInt("NSTEP");
         protocol.requireDouble("TSTEP");
         protocol.requireInt("NFLEVG");
+        protocol.requireInt("WSTEP");
         return protocol;
     }
 

--- a/src/ee_registry/README.md
+++ b/src/ee_registry/README.md
@@ -8,6 +8,15 @@ extreme event plugin configuration. Anchors can be used to avoid errors and dupl
 The `enabled` key is optional, it can be set to `false` to keep an event in the configuration but not run it in the plugin.
 This key is `true` by default if omitted.
 
+The `run_with_model` key is optional. It can be used when running the detection to filter events.
+Typically, it is possible that a subset of events run on wave fields, while another subset runs on atmospheric fields,
+and a third one runs on both. Depending on the simulation in which Plume is plugged, wave and atmosphere can run
+asynchronously, and sync every predetermined number of steps. Therefore, this key can be used to identify the model
+that triggerred the plugin run, so that wave events run at wave update frequency, atmospheric events run at
+atmospheric update frequency, and combined events run at sync frequency, etc. It is an int, and it defaults to `-1`,
+which means there is no particular filtering based on the caller, and all events will run every time the plugin is
+called without a tag. **Note:** Setting this key properly requires knowledge of the model in which Plume is plugged in.
+
 - [Extreme wind](#extreme-wind)
 - [Storm](#storm)
 - [Extreme wave](#extreme-wave)
@@ -56,6 +65,7 @@ parameters:
 name: "extreme_wind"
 enabled: true
 required_params: *extreme_wind
+run_with_model: 1
 instances:
   - lower_bound: 25.0 # this is a threshold
     upper_bound: 0.0

--- a/src/ee_registry/ee_base.h
+++ b/src/ee_registry/ee_base.h
@@ -10,6 +10,8 @@
  */
 #ifndef EE_BASE_H
 #define EE_BASE_H
+#include <cmath>
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -28,6 +30,29 @@ private:
 protected:
     std::vector<std::string> requiredParams_;
     std::vector<std::string> requiredFields_;
+    int caller_;  ///< member identifying which model call will actually trigger the detection
+
+    /**
+     * @brief Reads the model data to know how many seconds of simulation have run.
+     *
+     * `NSTEP` and `TSTEP` are unconditionnally requested by the plugin as they are usually among the set of always
+     * offered parameters, so they do not need to be requested per event, and can be queried anywhere in the plugin.
+     *
+     * @param modelData The model data offered through Plume.
+     */
+    static int elapsedSeconds(plume::data::ModelData& modelData) {
+        return static_cast<int>(std::round(modelData.getInt("NSTEP") * modelData.getDouble("TSTEP")));
+    }
+
+    /**
+     * @brief Reads the model data to know how many seconds of wave simulation have run.
+     *
+     * `WSTEP` is unconditionnally requested by the plugin as it usually is among the set of always offered parameters,
+     * so it does not need to be requested per event, and can be queried anywhere in the plugin.
+     *
+     * @param modelData The model data offered through Plume.
+     */
+    static int waveElapsedSeconds(plume::data::ModelData& modelData) { return modelData.getInt("WSTEP"); }
 
 public:
     /// Default constructor.
@@ -39,12 +64,15 @@ public:
      * All events should have a `required_params` key, even if empty, even though it is unlikely that an event
      * does not require anything from the model data. Each event is responsible for ensuring it accepts the
      * provided configuration.
+     * By default, the pointer to get the simulation time is set to use the main step model params. Each event can
+     * modify that individually, for instance, if their frequency is based on wave update.
      *
      * @param config The configuration for the extreme event. Each event has a different set of options, see
      *               their documentation for more details.
      * @param type The type of extreme event.
      */
-    ExtremeEvent(const eckit::LocalConfiguration& config, const std::string& type) {
+    ExtremeEvent(const eckit::LocalConfiguration& config, const std::string& type) :
+        caller_(config.getInt("run_with_model", -1)), simulatedSeconds(elapsedSeconds) {
         for (const auto& param : config.getSubConfigurations("required_params")) {
             if (param.getString("type") == "atlas_field") {
                 requiredFields_.push_back(param.getString("name"));
@@ -89,9 +117,13 @@ public:
      */
     virtual std::vector<DetectionData> detect(plume::data::ModelData& modelData) = 0;
 
+    std::function<int(plume::data::ModelData& modelData)>
+        simulatedSeconds;  ///< Associated with wave or atmospheric version depending on event
+
     /// Getters
     std::vector<std::string> requiredParams() const { return requiredParams_; }
     std::vector<std::string> requiredFields() const { return requiredFields_; }
+    int getCaller() const { return caller_; }
 };
 
 #endif  // EE_BASE_H

--- a/src/ee_registry/extreme_wave.cc
+++ b/src/ee_registry/extreme_wave.cc
@@ -53,6 +53,9 @@ ExtremeWave::ExtremeWave(const eckit::LocalConfiguration& config, plume::data::M
     // Sort thresholds by decreasing values (as high thresholds should automatically trigger small thresholds)
     std::sort(thresholds_.begin(), thresholds_.end(),
               [](const Threshold& a, const Threshold& b) { return a.value > b.value; });
+
+    // Associate the function pointer to derive sim time from wave model data
+    simulatedSeconds = waveElapsedSeconds;
 }
 
 std::vector<ExtremeEvent::DetectionData> ExtremeWave::detect(plume::data::ModelData& modelData) {


### PR DESCRIPTION
This PR goes with the corresponding Plume PR: https://github.com/ecmwf/plume/pull/16
It adds support for tagged runs. The configuration has to establish the mapping between the caller and the model, then the plugin applies this filtering if a caller is passed such that only a subset of loaded event can be run.