### PR TITLE
PLUME-14: Build the plugin in both SP and DP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,32 @@ ecbuild_find_package( NAME eckit  VERSION  1.28.5   REQUIRED )
 ecbuild_find_package( NAME atlas  VERSION  0.41 REQUIRED )
 ecbuild_find_package( NAME plume  VERSION  0.3.0  REQUIRED )
 
-ecbuild_add_option(FEATURE EE_PLUGIN_SINGLE_PRECISION DESCRIPTION "Single precision Atlas fields" DEFAULT OFF)
+# The plugin can be built in Single Precision (SP) and/or Double Precision (DP)
+ecbuild_add_option( FEATURE SINGLE_PRECISION
+                    DESCRIPTION "Compile plugin in single precision"
+                    DEFAULT OFF )
 
-if( HAVE_EE_PLUGIN_SINGLE_PRECISION ) 
-  list(APPEND PLUGINS_DEFINITIONS WITH_EE_PLUGIN_SINGLE_PRECISION )
+ecbuild_add_option( FEATURE PLUME_PLUGINS_SINGLE_PRECISION
+                    DESCRIPTION
+                    "Compile plugin for single precision fields"
+                    DEFAULT OFF)
+
+ecbuild_add_option( FEATURE PLUME_PLUGINS_DOUBLE_PRECISION
+                    DESCRIPTION
+                    "Compile plugin for double precision fields"
+                    DEFAULT ON)
+
+set( HAVE_EE_PLUGIN_sp 0)
+set( HAVE_EE_PLUGIN_dp 0)
+
+if (HAVE_SINGLE_PRECISION OR HAVE_PLUME_PLUGINS_SINGLE_PRECISION)
+  set( PLUGINS_DEFINITIONS_sp WITH_EE_PLUGIN_SINGLE_PRECISION )
+  set( HAVE_EE_PLUGIN_sp 1)
+endif()
+
+if (HAVE_PLUME_PLUGINS_DOUBLE_PRECISION)
+  set( PLUGINS_DEFINITIONS_dp WITH_EE_PLUGIN_DOUBLE_PRECISION )
+  set( HAVE_EE_PLUGIN_dp 1)
 endif()
 
 ## Plugins

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,24 +56,30 @@ set(EE_PLUGIN_SOURCES
     ${EE_PLUGIN_FILES_H}
     ${EE_PLUGIN_FILES_CC}
 )
+foreach(prec sp dp)
+    if (HAVE_EE_PLUGIN_${prec})
+        set(EE_PLUGIN_LIB_NAME "extreme_event_plugin_${prec}")
+        message(STATUS "Building plugin ${EE_PLUGIN_LIB_NAME} and definitions: ${PLUGINS_DEFINITIONS_${prec}}")
 
-ecbuild_add_library(
-    TARGET extreme_event_plugin
-    INSTALL_HEADERS LISTED
-    HEADER_DESTINATION
-        ${INSTALL_INCLUDE_DIR}/plume-plugin-extreme-events
-    SOURCES
-        ${EE_PLUGIN_SOURCES}
-    PUBLIC_INCLUDES
-       $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>
-       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
-    PRIVATE_INCLUDES
-        "${MPI_INCLUDE_DIRS}"
-    DEFINITIONS
-        ${PLUGINS_DEFINITIONS}
-    PUBLIC_LIBS
-        atlas
-        eckit
-        plume
-        plume_plugin
-)
+        ecbuild_add_library(
+            TARGET ${EE_PLUGIN_LIB_NAME}
+            INSTALL_HEADERS LISTED
+            HEADER_DESTINATION
+                ${INSTALL_INCLUDE_DIR}/plume-plugin-extreme-events-${prec}
+            SOURCES
+                ${EE_PLUGIN_SOURCES}
+            PUBLIC_INCLUDES
+                $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>
+                $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+            PRIVATE_INCLUDES
+                "${MPI_INCLUDE_DIRS}"
+            DEFINITIONS
+                ${PLUGINS_DEFINITIONS_${prec}}
+            PUBLIC_LIBS
+                atlas
+                eckit
+                plume
+                plume_plugin
+        )
+    endif()
+endforeach()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,8 @@ set(EE_PLUGIN_TEST_FILES_H
     ../src/ee_registry/extreme_wind.h
     ../src/ee_registry/storm.h
     ../src/ee_registry/extreme_wave.h
+    ../src/ee_registry/wind_drought.h
+    ../src/ee_registry/ramp.h
     ../src/plugin_types.h
 )
 
@@ -22,6 +24,8 @@ set(EE_PLUGIN_TEST_FILES_CC
     ../src/ee_registry/extreme_wind.cc
     ../src/ee_registry/storm.cc
     ../src/ee_registry/extreme_wave.cc
+    ../src/ee_registry/wind_drought.cc
+    ../src/ee_registry/ramp.cc
 )
 
 set(EE_PLUGIN_TEST_SOURCES
@@ -29,30 +33,38 @@ set(EE_PLUGIN_TEST_SOURCES
     ${EE_PLUGIN_TEST_FILES_CC}
 )
 
-ecbuild_add_test (
-    TARGET ee_plugin_test_core
-    SOURCES
-        ${EE_PLUGIN_TEST_SOURCES}
-        test_ee_plugin.cc
-    INCLUDES
-        ${CMAKE_CURRENT_SOURCE_DIR}/../src
-        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>
-    LIBS
-        eckit
-        plume_plugin
-)
+foreach(prec sp dp)
+    if (HAVE_EE_PLUGIN_${prec})
+        ecbuild_add_test (
+            TARGET ee_plugin_test_core_${prec}
+            SOURCES
+                ${EE_PLUGIN_TEST_SOURCES}
+                test_ee_plugin.cc
+            INCLUDES
+                ${CMAKE_CURRENT_SOURCE_DIR}/../src
+                $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>
+            LIBS
+                eckit
+                plume_plugin
+        )
+    endif()
+endforeach()
 
-ecbuild_add_test(
-    TARGET  ee_plugin_run_test
-    COMMAND nwp_emulator_run.x
-    ENVIRONMENT CLASS="test"
-                TYPE="test"
-                EXPVER="0001"
-                DATE="00000000"
-                TIME="0000"
-                PLUME_PLUGIN_DEV=1
-                DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{DYLD_LIBRARY_PATH}
-                LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}
-    ARGS --config-src=${CMAKE_CURRENT_SOURCE_DIR}/data/emulator_config.yml
-         --plume-cfg=${CMAKE_CURRENT_SOURCE_DIR}/data/plume_config.yml
-)
+foreach(prec sp dp)
+    if (HAVE_EE_PLUGIN_${prec})
+        ecbuild_add_test(
+            TARGET  ee_plugin_run_test_${prec}
+            COMMAND nwp_emulator_run_${prec}.x
+            ENVIRONMENT CLASS="test"
+                        TYPE="test"
+                        EXPVER="0001"
+                        DATE="00000000"
+                        TIME="0000"
+                        PLUME_PLUGIN_DEV=1
+                        DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{DYLD_LIBRARY_PATH}
+                        LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}
+            ARGS --config-src=${CMAKE_CURRENT_SOURCE_DIR}/data/emulator_config.yml
+                --plume-cfg=${CMAKE_CURRENT_SOURCE_DIR}/data/plume_config_${prec}.yml
+        )
+    endif()
+endforeach()

--- a/tests/data/plume_config_dp.yml
+++ b/tests/data/plume_config_dp.yml
@@ -1,0 +1,64 @@
+plugins:
+  - name: "EEPlugin"
+    lib: "extreme_event_plugin_dp"
+    parameters:
+      - &extreme_wind
+        - name: "u"
+          type: "atlas_field"
+        - name: "v"
+          type: "atlas_field"
+        - name: "100u"
+          type: "atlas_field"
+        - name: "100v"
+          type: "atlas_field"
+      - &100m_wind
+        - name: "100u"
+          type: "atlas_field"
+        - name: "100v"
+          type: "atlas_field"
+      - &waves
+        - name: "swh"
+          type: "atlas_field"
+      - &temperatureRamp
+        - name: "2t"
+          type: "atlas_field"
+    core-config:
+        aviso_url: "test"
+        notify_endpoint: "/test"
+        enable_notification: true
+        healpix_res: 16
+        events:
+          - name: "extreme_wind"
+            enabled: true
+            required_params: *extreme_wind
+            instances:
+              - lower_bound: 25.0
+                upper_bound: 0.0
+                description: "Extremely strong wind"
+              - lower_bound: 0.0
+                upper_bound: 0.5
+                model_levels: [1, 2]
+                description: "No wind"
+          - name: "storm"
+            enabled: true
+            required_params: *100m_wind
+            wind_speed_cutout: 20.0
+            time_window: 60
+          - name: "extreme_wave"
+            enabled: true
+            required_params: *waves
+            instances:
+              - threshold: 8.0
+                description: "Storm conditions"
+              - threshold: 3.5
+                description: "Unsafe offshore wind-farm operations"
+          - name: "wind_drought"
+            enabled: true
+            required_params: *100m_wind
+            wind_speed_cutout: 2.0
+            time_window: 15
+          - name: "ramp"
+            enabled: true
+            required_params: *temperatureRamp
+            ramp_up_value: 10.0
+            time_window: 60

--- a/tests/data/plume_config_sp.yml
+++ b/tests/data/plume_config_sp.yml
@@ -1,6 +1,6 @@
 plugins:
   - name: "EEPlugin"
-    lib: "extreme_event_plugin"
+    lib: "extreme_event_plugin_sp"
     parameters:
       - &extreme_wind
         - name: "u"


### PR DESCRIPTION
This PR introduces the possibility to build the plugin both for single and double precision (or either or).
In order for the tests using the plume emulator to pass, it requires the changes in [this Plume PR](https://github.com/ecmwf/plume/pull/18).