### PR TITLE
PLUME-49: Add tests using Plume NWP emulator optionally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,11 @@ if (HAVE_PLUME_PLUGINS_DOUBLE_PRECISION)
   set( HAVE_EE_PLUGIN_dp 1)
 endif()
 
+# Tests using the Plume NWP Emulator are optional
+ecbuild_add_option( FEATURE NWP_EMULATOR_TESTS
+                    DESCRIPTION "Add plugin tests using the Plume NWP emulator"
+                    DEFAULT ON )
+
 ## Plugins
 add_subdirectory(src)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,7 +51,7 @@ foreach(prec sp dp)
 endforeach()
 
 foreach(prec sp dp)
-    if (HAVE_EE_PLUGIN_${prec})
+    if (HAVE_EE_PLUGIN_${prec} AND HAVE_NWP_EMULATOR_TESTS)
         ecbuild_add_test(
             TARGET  ee_plugin_run_test_${prec}
             COMMAND nwp_emulator_run_${prec}.x


### PR DESCRIPTION
### Description

This PR adds support to the changes introduced in this [Plume PR](https://github.com/ecmwf/plume/pull/19). As Plume can be built without the emulator, any tests running the emulator need to be disabled when the emulator is not built. Therefore, when the emulator tests are disabled, only the rest of the test suite is built.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 