### PR TITLE
PLUME-37: Add event filtering based on fields updated status

### DIFF
--- a/src/ee_plugin.cc
+++ b/src/ee_plugin.cc
@@ -63,6 +63,11 @@ void EEPluginCore::run() {
     // Determine the elapsed time in the simulation in minutes
     std::string elapsedTime = modelStepStr();
     for (auto& ee : extremeEvents_) {
+        // Determine whether or not the event should run
+        if (!std::any_of(ee->requiredFields().begin(), ee->requiredFields().end(),
+                         [this](const std::string& name) { return modelData().isUpdated(name); })) {
+            continue;  // A single updated field is enough to allow the detection
+        }
         // Run the detection for each extreme event suite
         auto results = ee->detect(modelData());
         for (size_t idx = 0; idx < results.size(); ++idx) {
@@ -119,7 +124,7 @@ std::string EEPluginCore::modelStepStr() {
 
 // ------------------------------------------------------
 
-EEPlugin::EEPlugin() : Plugin("EEPlugin"){};
+EEPlugin::EEPlugin() : Plugin("EEPlugin") {};
 
 const EEPlugin& EEPlugin::instance() {
     static EEPlugin instance;

--- a/src/ee_registry/ee_base.h
+++ b/src/ee_registry/ee_base.h
@@ -90,8 +90,9 @@ public:
     virtual std::vector<DetectionData> detect(plume::data::ModelData& modelData) = 0;
 
     /// Getters
-    std::vector<std::string> requiredParams() const { return requiredParams_; }
-    std::vector<std::string> requiredFields() const { return requiredFields_; }
+    const std::vector<std::string>& requiredParams() const { return requiredParams_; }
+    const std::vector<std::string>& requiredFields() const { return requiredFields_; }
+    virtual const std::string& type() const = 0;
 };
 
 #endif  // EE_BASE_H

--- a/src/ee_registry/extreme_wave.h
+++ b/src/ee_registry/extreme_wave.h
@@ -69,6 +69,13 @@ public:
      */
     std::vector<ExtremeEvent::DetectionData> detect(plume::data::ModelData& modelData) override;
 
+    /**
+     * @brief Returns the type/name of the extreme event as used in the configuration.
+     */
+    const std::string& type() const override {
+        return type_;
+    }
+
     /// Register the extreme wave event into the registry so it can be used in the plugin.
     static struct Registrar {
         Registrar() {

--- a/src/ee_registry/extreme_wind.h
+++ b/src/ee_registry/extreme_wind.h
@@ -70,6 +70,13 @@ public:
      */
     std::vector<ExtremeEvent::DetectionData> detect(plume::data::ModelData& modelData) override;
 
+    /**
+     * @brief Returns the type/name of the extreme event as used in the configuration.
+     */
+    const std::string& type() const override {
+        return type_;
+    }
+
     /// Register the extreme wind event into the registry so it can be used in the plugin.
     static struct Registrar {
         Registrar() {

--- a/src/ee_registry/ramp.h
+++ b/src/ee_registry/ramp.h
@@ -72,6 +72,13 @@ public:
      */
     std::vector<ExtremeEvent::DetectionData> detect(plume::data::ModelData& modelData) override;
 
+    /**
+     * @brief Returns the type/name of the extreme event as used in the configuration.
+     */
+    const std::string& type() const override {
+        return type_;
+    }
+
     /// Register the ramp event into the registry so it can be used in the plugin.
     static struct Registrar {
         Registrar() {

--- a/src/ee_registry/storm.h
+++ b/src/ee_registry/storm.h
@@ -73,6 +73,13 @@ public:
      */
     std::vector<ExtremeEvent::DetectionData> detect(plume::data::ModelData& modelData) override;
 
+    /**
+     * @brief Returns the type/name of the extreme event as used in the configuration.
+     */
+    const std::string& type() const override {
+        return type_;
+    }
+
     /// Register the storm event into the registry so it can be used in the plugin.
     static struct Registrar {
         Registrar() {

--- a/src/ee_registry/wind_drought.h
+++ b/src/ee_registry/wind_drought.h
@@ -67,6 +67,13 @@ public:
      */
     std::vector<ExtremeEvent::DetectionData> detect(plume::data::ModelData& modelData) override;
 
+    /**
+     * @brief Returns the type/name of the extreme event as used in the configuration.
+     */
+    const std::string& type() const override {
+        return type_;
+    }
+
     /// Register the wind drought event into the registry so it can be used in the plugin.
     static struct Registrar {
         Registrar() {


### PR DESCRIPTION
### Description

This PR is draft until the approach of [this PR](https://github.com/ecmwf/plume/pull/20) is confirmed.
Adds an event filtering feature in the run method based on the updated status of the parameters.
This mechanism allows to have multiple entry points in the model running only a subset of the loaded events, similarly to [ this PR](https://github.com/ecmwf/plume-plugin-extreme-events/pull/9), without the need for run tags and configuration.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 