### PR TITLE
Migration to GRIB2 wind fields

### DIFF
--- a/.github/ci-config.yml
+++ b/.github/ci-config.yml
@@ -7,5 +7,8 @@ dependencies: |
   ecmwf/plume
 dependency_cmake_options: |
   ecmwf/atlas: "-DENABLE_FORTRAN=ON"
+  ecmwf/plume: "-DPLUME_ENABLE_NWP_EMULATOR=ON -DPLUME_ENABLE_NWP_EMULATOR_SINGLE_PRECISION=ON -DPLUME_ENABLE_NWP_EMULATOR_DOUBLE_PRECISION=ON"
+cmake_options: |
+  -DPLUME_PLUGIN_EXTREME_EVENTS_ENABLE_NWP_EMULATOR_TESTS=ON
 dependency_branch: develop
 parallelism_factor: 8

--- a/.github/ci-hpc-config.yml
+++ b/.github/ci-hpc-config.yml
@@ -10,4 +10,7 @@ build:
     - ecmwf/plume@develop
   dependency_cmake_options:
     - ecmwf/atlas:-DENABLE_FORTRAN=ON
+    - ecmwf/plume:-DPLUME_ENABLE_NWP_EMULATOR=ON -DPLUME_ENABLE_NWP_EMULATOR_SINGLE_PRECISION=ON -DPLUME_ENABLE_NWP_EMULATOR_DOUBLE_PRECISION=ON
+  cmake_options:
+    - -DPLUME_PLUGIN_EXTREME_EVENTS_ENABLE_NWP_EMULATOR_TESTS=ON
   parallel: 64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 ecbuild_find_package( NAME eckit  VERSION  1.28.5   REQUIRED )
 ecbuild_find_package( NAME atlas  VERSION  0.41 REQUIRED )
-ecbuild_find_package( NAME plume  VERSION  0.3.0  REQUIRED )
+ecbuild_find_package( NAME plume  VERSION  0.5.0  REQUIRED )
 
 # The plugin can be built in Single Precision (SP) and/or Double Precision (DP)
 ecbuild_add_option( FEATURE SINGLE_PRECISION
@@ -53,7 +53,7 @@ endif()
 # Tests using the Plume NWP Emulator are optional
 ecbuild_add_option( FEATURE NWP_EMULATOR_TESTS
                     DESCRIPTION "Add plugin tests using the Plume NWP emulator"
-                    DEFAULT ON )
+                    DEFAULT OFF )
 
 ## Plugins
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -70,8 +70,10 @@ plugins:
       - &extreme_wind
         - name: "u"
           type: "ATLAS_FIELD"
+          height: 250
         - name: "v"
           type: "ATLAS_FIELD"
+          height: 250
     core-config:
         aviso_url: "<url/to/aviso/server>"
         notify_endpoint: "/notify/endpoint"

--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ Once installed, this plugin can easily be run with the [Plume emulator](https://
 bash <exec_bin>/emulate_ee_detection.sh --dev --np=8 --expver="0002" --config-src=<path/to/emulator_config.yml> --plume-cfg=<path/to/plume_config.yml>
 ```
 
+Run `bash <exec_bin>/emulate_ee_detection.sh [--help|-h]` for all the available options.
+The emulator will run in single precision by default, add `--sp` flag for single precision.
+
 # Contributors
 
 Thank you to all the wonderful people who have contributed to the Extreme Event Detection Plume plugin.

--- a/README.md
+++ b/README.md
@@ -68,10 +68,12 @@ plugins:
     lib: "extreme_event_plugin"
     parameters:
       - &extreme_wind
-        - name: "100u"
+        - name: "u"
           type: "atlas_field"
-        - name: "100v"
+          height: 250
+        - name: "v"
           type: "atlas_field"
+          height: 250
     core-config:
         aviso_url: "<url/to/aviso/server>"
         notify_endpoint: "/notify/endpoint"

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ plugins:
     lib: "extreme_event_plugin"
     parameters:
       - &extreme_wind
-        - name: "100u"
-          type: "atlas_field"
-        - name: "100v"
-          type: "atlas_field"
+        - name: "u"
+          type: "ATLAS_FIELD"
+        - name: "v"
+          type: "ATLAS_FIELD"
     core-config:
         aviso_url: "<url/to/aviso/server>"
         notify_endpoint: "/notify/endpoint"
@@ -139,6 +139,9 @@ Once installed, this plugin can easily be run with the [Plume emulator](https://
 ```bash
 bash <exec_bin>/emulate_ee_detection.sh --dev --np=8 --expver="0002" --config-src=<path/to/emulator_config.yml> --plume-cfg=<path/to/plume_config.yml>
 ```
+
+Run `bash <exec_bin>/emulate_ee_detection.sh [--help|-h]` for all the available options.
+The emulator will run in double precision by default, add `--sp` flag for single precision.
 
 # Contributors
 

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ plugins:
     parameters:
       - &extreme_wind
         - name: "u"
-          type: "atlas_field"
+          type: "ATLAS_FIELD"
           height: 250
         - name: "v"
-          type: "atlas_field"
+          type: "ATLAS_FIELD"
           height: 250
     core-config:
         aviso_url: "<url/to/aviso/server>"
@@ -143,7 +143,7 @@ bash <exec_bin>/emulate_ee_detection.sh --dev --np=8 --expver="0002" --config-sr
 ```
 
 Run `bash <exec_bin>/emulate_ee_detection.sh [--help|-h]` for all the available options.
-The emulator will run in single precision by default, add `--sp` flag for single precision.
+The emulator will run in double precision by default, add `--sp` flag for single precision.
 
 # Contributors
 

--- a/scripts/emulate_ee_detection.sh.in
+++ b/scripts/emulate_ee_detection.sh.in
@@ -16,6 +16,12 @@ emulator_src=""
 njobs=1
 expver="0000"
 dev=0
+precision="dp"
+
+usage() {
+    echo "Usage: $0 --plume-cfg=<path> [--grib-src=<path> | --config-src=<path>]
+                                       [--expver=<id>] [--np=<n>] [--sp] [--dev]"
+}
 
 echo "Run extreme event detection plugin with emulator :"
 
@@ -36,6 +42,14 @@ while [[ $# -gt 0 ]]; do
         --dev)
             dev=1
             shift
+            ;;
+        --sp)
+            precision="sp"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
             ;;
         --grib-src=*|--config-src=*)
             if [[ -n "$emulator_src" ]]; then
@@ -67,14 +81,16 @@ export PLUME_PLUGIN_DEV=$dev
 # Run with config OR grib source
 if [[ -z "$emulator_src" ]]; then
     echo "Provide either of these options: [--grib-src=<path> | --config-src=<path>]"
+    usage
     exit 1
 fi
 if [[ -z "$plume_config" ]]; then
     echo "--plume-cfg=<path> is missing from the command"
+    usage
     exit 1
 fi
 
-mpirun -np $njobs $exe_dir/nwp_emulator_run.x $emulator_src $plume_config
+mpirun -np $njobs $exe_dir/nwp_emulator_run_${precision}.x $emulator_src $plume_config
 
 echo "Tearing down environment variables..."
 unset CLASS TYPE EXPVER DATE TIME PLUME_PLUGIN_DEV

--- a/src/ee_plugin.cc
+++ b/src/ee_plugin.cc
@@ -41,13 +41,17 @@ void EEPluginCore::setup() {
             continue;
         }
         // Load only the extreme events that require offered parameters
-        bool hasRequiredParams = true;
-        for (const auto& param : ee.getSubConfigurations("required_params")) {
-            if (!modelData().hasParameter(param.getString("name"))) {
-                hasRequiredParams = false;
-                break;
-            }
-        }
+        const auto& requiredParams = ee.getSubConfigurations("required_params");
+        const bool hasRequiredParams = std::all_of(
+            requiredParams.begin(),
+            requiredParams.end(),
+            [this](const eckit::Configuration& param) {
+                // Any other derivation than height levels is currently not supported
+                const std::string heightStr = param.getString("height", "");
+                const std::string name = param.getString("name");
+                return heightStr.empty() ? modelData().hasParameter(name)
+                                         : modelData().hasParameter(name, heightStr);
+            });
         if (hasRequiredParams) {
             extremeEvents_.push_back(ExtremeEventRegistry::instance().createEvent(ee, modelData(), Point2HPcell_));
             eckit::Log::info() << ee.getString("name") << " ";
@@ -64,9 +68,19 @@ void EEPluginCore::run() {
     std::string elapsedTime = modelStepStr();
     for (auto& ee : extremeEvents_) {
         // Determine whether or not the event should run
-        if (!std::any_of(ee->requiredFields().begin(), ee->requiredFields().end(),
-                         [this](const std::string& name) { return modelData().isUpdated(name); })) {
-            continue;  // A single updated field is enough to allow the detection
+        const auto& requiredParams = ee->requiredParams();
+        const auto& requiredFields = ee->requiredFields();
+        const auto& heightLevel = ee->heightLevel();
+        const bool paramUpdated = std::any_of(requiredParams.begin(), requiredParams.end(),
+                                              [this](const std::string& name) { return modelData().isUpdated(name); });
+        const bool fieldUpdated = std::any_of(
+            requiredFields.begin(), requiredFields.end(),
+            [this, &heightLevel](const std::string& name) {
+                return heightLevel.has_value() ? modelData().isUpdated(name, std::to_string(*heightLevel))
+                                               : modelData().isUpdated(name);
+            });
+        if (!paramUpdated && !fieldUpdated) {
+            continue;  // A single updated field or param is enough to allow the detection
         }
         // Run the detection for each extreme event suite
         auto results = ee->detect(modelData());
@@ -100,15 +114,15 @@ void EEPluginCore::run() {
 void EEPluginCore::setHEALPixMapping() {
     // TODO: Should this plugin handle multiple functionspaces if fields passed are not all on the same mesh?
     // Retrieve the function space from the model data
-    auto fs = modelData().getAtlasFieldShared(modelData().listAvailableParameters("ATLAS_FIELD")[0]).functionspace();
+    auto fs = modelData().getParam<atlas::Field>(modelData().listAvailableParameters("ATLAS_FIELD")[0]).functionspace();
     mapLonLatToHEALPixCell(healpixRes_, fs, Point2HPcell_, HPcell2polygon_);
 }
 
 std::string EEPluginCore::modelStepStr() {
-    if (modelData().getInt("NSTEP") == 0) {
+    if (modelData().getParam<int>("NSTEP") == 0) {
         return "0s";
     }
-    int seconds = static_cast<int>(std::round(modelData().getInt("NSTEP") * modelData().getDouble("TSTEP")));
+    int seconds = static_cast<int>(std::round(modelData().getParam<int>("NSTEP") * modelData().getParam<double>("TSTEP")));
     // Sub-hourly supported time units (except for seconds)
     const std::vector<std::pair<int, std::string>> timeUnits = {{86400, "d"}, {3600, "h"}, {60, "m"}};
     for (const auto& unit : timeUnits) {

--- a/src/ee_plugin.h
+++ b/src/ee_plugin.h
@@ -132,9 +132,10 @@ public:
      */
     plume::Protocol negotiate() override {
         plume::Protocol protocol;
-        protocol.requireInt("NSTEP");
-        protocol.requireDouble("TSTEP");
-        protocol.requireInt("NFLEVG");
+        protocol.require<int>("NSTEP");
+        protocol.require<int>("WSTEP");
+        protocol.require<double>("TSTEP");
+        protocol.require<int>("NFLEVG");
         return protocol;
     }
 

--- a/src/ee_registry/README.md
+++ b/src/ee_registry/README.md
@@ -21,14 +21,15 @@ This key is `true` by default if omitted.
 This event with name `extreme_wind` detects winds above a specified threshold or within a specified range.
 It scans the fields that are in the `required_params`, computes the wind magnitude from the horizontal and vertical
 components (or only one of them if the other is not offered), and flags the grid points that exceed the threshold or
-fall in the range. The same `extreme_wind` event can be used to detect on several fields or several thresholds, via
+fall in the range. The same `extreme_wind` event can be used to detect on model levels or several thresholds, via
 configuring the `instances` list key. Each element represents a set of detection options: `lower_bound`, `upper_bound`,
-a human-readable `description`, and optionally, if non surface fields are passed, `model_levels`.
+a human-readable `description`, and optionally, if non 2D fields are passed, `model_levels`.
 
 
 > [!NOTE]
-> A `height` option may be added in the future for non surface fields for users who might be interested in detecting
-high winds at a specific height, e.g., wind turbine height.
+> Users can provide a `height` option in the required parameters if they are interested in detecting
+> high winds at a specific height, e.g., wind turbine height. In that case, model levels cannot
+> be passed to the configuration. Separate events must be configured to detect at several heights.
 
 
 ### Configuration examples
@@ -37,7 +38,7 @@ high winds at a specific height, e.g., wind turbine height.
 > Validation is run on the instances when the extreme wind object is constructed. Bad values will throw excecptions.
 
 Things to keep in mind when writing your configuration:
-- ensure your instances have the proper parameters for your field types (`model_levels` is required for non surface fields).
+- ensure your instances have the proper parameters for your field types (`model_levels` is required for 3D fields).
 - ensure the vertical levels you request are not higher than the model levels.
 - if you want to use a threshold and not a range, make sure to input your threshold in `lower_bound` and set the 
 `upper_bound` to a smaller number.
@@ -48,10 +49,12 @@ root of the plugin configuration.
 ```yaml
 parameters:
   - &extreme_wind
-    - name: "100u"
-      type: "atlas_field"
-    - name: "100v"
-      type: "atlas_field"
+    - name: "u"
+      type: "ATLAS_FIELD"
+      height: 100
+    - name: "v"
+      type: "ATLAS_FIELD"
+      height: 100
 ...
 name: "extreme_wind"
 enabled: true
@@ -69,9 +72,9 @@ instances:
 parameters:
   - &extreme_wind
     - name: "u"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
     - name: "v"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
 ...
 name: "extreme_wind"
 required_params: *extreme_wind
@@ -82,40 +85,84 @@ instances:
     description: "Extremely strong wind"
 ```
 
-You can use a combination of surface and non surface fields in your parameters, based on the instances options,
-the extreme wind event will determine which instance should run on which fields.
+Required parameters apply to all instances, so it is not possible to use a combination of 2D and 3D 
+fields, or multiple 2D fields at different heights, in the same `extreme_wind` event, e.g., correct configuration:
+
+```yaml
+parameters:
+  - &extreme_wind
+    - name: "u"
+      type: "ATLAS_FIELD"
+    - name: "v"
+      type: "ATLAS_FIELD"
+  - &100m_extreme_wind
+    - name: "u"
+      type: "ATLAS_FIELD"
+      height: 100
+    - name: "v"
+      type: "ATLAS_FIELD"
+      height: 100
+...
+events:
+  - name: "extreme_wind"
+    required_params: *extreme_wind
+    instances:
+      - lower_bound: 30.0
+        upper_bound: 0.0
+        model_levels: [1, 66, 137]
+  - name: "extreme_wind"
+    enabled: true
+    required_params: *100m_extreme_wind
+    instances:
+      - lower_bound: 25.0
+        upper_bound: 0.0
+```
 
 ## Storm
 
 ### Description
 
-This event with name `storm` uses a minimal definition solely based on 100m wind components to serve as baseline,
+This event with name `storm` uses a minimal definition solely based on wind speed components to serve as baseline,
 but may be refined in the future. Detection is triggered when the wind (1+ grid point in the coarse cell) exceeds a
 given threshold over a specified time window.
 
 This event stores the wind speed for each grid point and each time step in the time window.
 
-The initial implementation of this event makes use of the `100u` and `100v` fields from GRIB 1.
-It will be migrated to GRIB 2 to use `u` and `v` at height level `100` in the future.
+This event uses `u` and `v` fields at any given height level or model level.
 
 ### Configuration examples
 
-Only `100u` and `100v` fields are allowed at the moment. The event requires only two options:
+Only `u` and `v` fields are allowed at the moment, as the detection method relies only on the wind.
+The event requires only two keys, and has an optional one:
 - The wind speed threshold: expressed in m/s, only two decimals of precision are used by the algorithm,
 so anything more precise will be truncated. The algorithm will throw an error if the number provided is negative.
 - The time window: expressed in minutes. If the time window is smaller than the internal model time step,
 the detection will run only on the current time step.
+- The model level: in case no height is provided, the event will rely on a model level being provided.
 
 ```yaml
 parameters:
   - &storm
-    - name: "100u"
-      type: "atlas_field"
-    - name: "100v"
-      type: "atlas_field"
+    - name: "u"
+      type: "ATLAS_FIELD"
+    - name: "v"
+      type: "ATLAS_FIELD"
+  - &100m_storm
+    - name: "u"
+      type: "ATLAS_FIELD"
+      height: 100
+    - name: "v"
+      type: "ATLAS_FIELD"
+      height: 100
 ...
 name: "storm"
 required_params: *storm
+wind_speed_cutout: 20.0
+time_window: 60
+model_level: 137
+...
+name: "storm"
+required_params: *100m_storm
 wind_speed_cutout: 20.0
 time_window: 60
 ```
@@ -146,7 +193,7 @@ represented by the missing value, and should not trigger the detection.
 parameters:
   - &extreme_waves
     - name: "swh"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
 ...
 name: "extreme_wave"
 required_params: *extreme_waves
@@ -168,24 +215,26 @@ from the electricity grid perspective, especially if combined with important clo
 It stores for each grid point the number of time steps where the wind stayed below a given threshold. The counters
 reset whenever the wind (spatial average over the coarse cell) exceeds the threshold.
 
-> [!NOTE]
-> The initial implementation of this event makes use of the `100u` and `100v` fields from GRIB 1.
-It will be migrated to GRIB 2 to use `u` and `v` at height level `100` in the future.
+This event uses `u` and `v` fields at any given height level or model level.
 
 ### Configuration examples
 
-Only `100u` and `100v` fields are allowed at the moment. The event requires only two options:
+The event requires only two options:
 - The wind speed threshold: expressed in m/s.
 - The time window: expressed in minutes. The typical order of magnitude for the time window for this event is hours or
   days, but they must be converted to minutes.
 
+If the 3D wind components are passed, this event also requires a `model_level` key.
+
 ```yaml
 parameters:
   - &wind_drought
-    - name: "100u"
-      type: "atlas_field"
-    - name: "100v"
-      type: "atlas_field"
+    - name: "u"
+      type: "ATLAS_FIELD"
+      height: 100
+    - name: "v"
+      type: "ATLAS_FIELD"
+      height: 100
 ...
 name: "wind_drought"
 required_params: *wind_drought
@@ -203,7 +252,7 @@ over a specified time window.
 
 This event stores the parameter(s) value for each grid point and each time step in the time window.
 In case multiple parameters are passed, their magnitude is computed as stored value. It lies with the user to ensure
-this quantity makes sense.
+this quantity makes sense. All parameters passed should be surface or height levels.
 
 ### Configuration examples
 
@@ -216,13 +265,15 @@ the detection will run only on the current time step.
 ```yaml
 parameters:
   - &windRamp
-    - name: "100u"
-      type: "atlas_field"
-    - name: "100v"
-      type: "atlas_field"
+    - name: "u"
+      type: "ATLAS_FIELD"
+      height: 100
+    - name: "v"
+      type: "ATLAS_FIELD"
+      height: 100
   - &temperatureRamp
     - name: "2t"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
 ...
 - name: "ramp"
   required_params: *windRamp

--- a/src/ee_registry/README.md
+++ b/src/ee_registry/README.md
@@ -21,14 +21,15 @@ This key is `true` by default if omitted.
 This event with name `extreme_wind` detects winds above a specified threshold or within a specified range.
 It scans the fields that are in the `required_params`, computes the wind magnitude from the horizontal and vertical
 components (or only one of them if the other is not offered), and flags the grid points that exceed the threshold or
-fall in the range. The same `extreme_wind` event can be used to detect on several fields or several thresholds, via
+fall in the range. The same `extreme_wind` event can be used to detect on model levels or several thresholds, via
 configuring the `instances` list key. Each element represents a set of detection options: `lower_bound`, `upper_bound`,
-a human-readable `description`, and optionally, if non surface fields are passed, `model_levels`.
+a human-readable `description`, and optionally, if non 2D fields are passed, `model_levels`.
 
 
 > [!NOTE]
-> A `height` option may be added in the future for non surface fields for users who might be interested in detecting
-high winds at a specific height, e.g., wind turbine height.
+> Users can provide a `height` option in the required parameters if they are interested in detecting
+> high winds at a specific height, e.g., wind turbine height. In that case, model levels cannot
+> be passed to the configuration. Separate events must be configured to detect at several heights.
 
 
 ### Configuration examples
@@ -37,7 +38,7 @@ high winds at a specific height, e.g., wind turbine height.
 > Validation is run on the instances when the extreme wind object is constructed. Bad values will throw excecptions.
 
 Things to keep in mind when writing your configuration:
-- ensure your instances have the proper parameters for your field types (`model_levels` is required for non surface fields).
+- ensure your instances have the proper parameters for your field types (`model_levels` is required for 3D fields).
 - ensure the vertical levels you request are not higher than the model levels.
 - if you want to use a threshold and not a range, make sure to input your threshold in `lower_bound` and set the 
 `upper_bound` to a smaller number.
@@ -48,10 +49,12 @@ root of the plugin configuration.
 ```yaml
 parameters:
   - &extreme_wind
-    - name: "100u"
+    - name: "u"
       type: "atlas_field"
-    - name: "100v"
+      height: 100
+    - name: "v"
       type: "atlas_field"
+      height: 100
 ...
 name: "extreme_wind"
 enabled: true
@@ -82,40 +85,84 @@ instances:
     description: "Extremely strong wind"
 ```
 
-You can use a combination of surface and non surface fields in your parameters, based on the instances options,
-the extreme wind event will determine which instance should run on which fields.
+Required parameters apply to all instances, so it is not possible to use a combination of 2D and 3D 
+fields, or multiple 2D fields at different heights, in the same `extreme_wind` event, e.g., correct configuration:
+
+```yaml
+parameters:
+  - &extreme_wind
+    - name: "u"
+      type: "atlas_field"
+    - name: "v"
+      type: "atlas_field"
+  - &100m_extreme_wind
+    - name: "u"
+      type: "atlas_field"
+      height: 100
+    - name: "v"
+      type: "atlas_field"
+      height: 100
+...
+events:
+  - name: "extreme_wind"
+    required_params: *extreme_wind
+    instances:
+      - lower_bound: 30.0
+        upper_bound: 0.0
+        model_levels: [1, 66, 137]
+  - name: "extreme_wind"
+    enabled: true
+    required_params: *100m_extreme_wind
+    instances:
+      - lower_bound: 25.0
+        upper_bound: 0.0
+```
 
 ## Storm
 
 ### Description
 
-This event with name `storm` uses a minimal definition solely based on 100m wind components to serve as baseline,
+This event with name `storm` uses a minimal definition solely based on wind speed components to serve as baseline,
 but may be refined in the future. Detection is triggered when the wind (1+ grid point in the coarse cell) exceeds a
 given threshold over a specified time window.
 
 This event stores the wind speed for each grid point and each time step in the time window.
 
-The initial implementation of this event makes use of the `100u` and `100v` fields from GRIB 1.
-It will be migrated to GRIB 2 to use `u` and `v` at height level `100` in the future.
+This event uses `u` and `v` fields at any given height level or model level.
 
 ### Configuration examples
 
-Only `100u` and `100v` fields are allowed at the moment. The event requires only two options:
+Only `u` and `v` fields are allowed at the moment, as the detection method relies only on the wind.
+The event requires only two keys, and has an optional one:
 - The wind speed threshold: expressed in m/s, only two decimals of precision are used by the algorithm,
 so anything more precise will be truncated. The algorithm will throw an error if the number provided is negative.
 - The time window: expressed in minutes. If the time window is smaller than the internal model time step,
 the detection will run only on the current time step.
+- The model level: in case no height is provided, the event will rely on a model level being provided.
 
 ```yaml
 parameters:
   - &storm
-    - name: "100u"
+    - name: "u"
       type: "atlas_field"
-    - name: "100v"
+    - name: "v"
       type: "atlas_field"
+  - &100m_storm
+    - name: "u"
+      type: "atlas_field"
+      height: 100
+    - name: "v"
+      type: "atlas_field"
+      height: 100
 ...
 name: "storm"
 required_params: *storm
+wind_speed_cutout: 20.0
+time_window: 60
+model_level: 137
+...
+name: "storm"
+required_params: *100m_storm
 wind_speed_cutout: 20.0
 time_window: 60
 ```
@@ -168,24 +215,26 @@ from the electricity grid perspective, especially if combined with important clo
 It stores for each grid point the number of time steps where the wind stayed below a given threshold. The counters
 reset whenever the wind (spatial average over the coarse cell) exceeds the threshold.
 
-> [!NOTE]
-> The initial implementation of this event makes use of the `100u` and `100v` fields from GRIB 1.
-It will be migrated to GRIB 2 to use `u` and `v` at height level `100` in the future.
+This event uses `u` and `v` fields at any given height level or model level.
 
 ### Configuration examples
 
-Only `100u` and `100v` fields are allowed at the moment. The event requires only two options:
+The event requires only two options:
 - The wind speed threshold: expressed in m/s.
 - The time window: expressed in minutes. The typical order of magnitude for the time window for this event is hours or
   days, but they must be converted to minutes.
 
+If the 3D wind components are passed, this event also requires a `model_level` key.
+
 ```yaml
 parameters:
   - &wind_drought
-    - name: "100u"
+    - name: "u"
       type: "atlas_field"
-    - name: "100v"
+      height: 100
+    - name: "v"
       type: "atlas_field"
+      height: 100
 ...
 name: "wind_drought"
 required_params: *wind_drought
@@ -203,7 +252,7 @@ over a specified time window.
 
 This event stores the parameter(s) value for each grid point and each time step in the time window.
 In case multiple parameters are passed, their magnitude is computed as stored value. It lies with the user to ensure
-this quantity makes sense.
+this quantity makes sense. All parameters passed should be surface or height levels.
 
 ### Configuration examples
 
@@ -216,10 +265,12 @@ the detection will run only on the current time step.
 ```yaml
 parameters:
   - &windRamp
-    - name: "100u"
+    - name: "u"
       type: "atlas_field"
-    - name: "100v"
+      height: 100
+    - name: "v"
       type: "atlas_field"
+      height: 100
   - &temperatureRamp
     - name: "2t"
       type: "atlas_field"

--- a/src/ee_registry/README.md
+++ b/src/ee_registry/README.md
@@ -50,10 +50,10 @@ root of the plugin configuration.
 parameters:
   - &extreme_wind
     - name: "u"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
       height: 100
     - name: "v"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
       height: 100
 ...
 name: "extreme_wind"
@@ -72,9 +72,9 @@ instances:
 parameters:
   - &extreme_wind
     - name: "u"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
     - name: "v"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
 ...
 name: "extreme_wind"
 required_params: *extreme_wind
@@ -92,15 +92,15 @@ fields, or multiple 2D fields at different heights, in the same `extreme_wind` e
 parameters:
   - &extreme_wind
     - name: "u"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
     - name: "v"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
   - &100m_extreme_wind
     - name: "u"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
       height: 100
     - name: "v"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
       height: 100
 ...
 events:
@@ -144,15 +144,15 @@ the detection will run only on the current time step.
 parameters:
   - &storm
     - name: "u"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
     - name: "v"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
   - &100m_storm
     - name: "u"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
       height: 100
     - name: "v"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
       height: 100
 ...
 name: "storm"
@@ -193,7 +193,7 @@ represented by the missing value, and should not trigger the detection.
 parameters:
   - &extreme_waves
     - name: "swh"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
 ...
 name: "extreme_wave"
 required_params: *extreme_waves
@@ -230,10 +230,10 @@ If the 3D wind components are passed, this event also requires a `model_level` k
 parameters:
   - &wind_drought
     - name: "u"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
       height: 100
     - name: "v"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
       height: 100
 ...
 name: "wind_drought"
@@ -266,14 +266,14 @@ the detection will run only on the current time step.
 parameters:
   - &windRamp
     - name: "u"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
       height: 100
     - name: "v"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
       height: 100
   - &temperatureRamp
     - name: "2t"
-      type: "atlas_field"
+      type: "ATLAS_FIELD"
 ...
 - name: "ramp"
   required_params: *windRamp

--- a/src/ee_registry/ee_base.h
+++ b/src/ee_registry/ee_base.h
@@ -10,6 +10,7 @@
  */
 #ifndef EE_BASE_H
 #define EE_BASE_H
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -25,9 +26,21 @@ class ExtremeEvent {
 private:
     const std::string type_ = "ExtremeEvent";
 
-protected:
-    std::vector<std::string> requiredParams_;
-    std::vector<std::string> requiredFields_;
+    /**
+     * @struct RequiredModelData
+     * @brief A representation of the `required_params` configuration key for validation or retrieval purposes.
+     * 
+     * @note The current implementation of the plugin only supports height levels for wind fields. If this were to
+     * evolve due to Plume field derivation capabilities expanding, this struct and the plugin setup will need to be
+     * refactored.
+     */
+    struct RequiredModelData {
+        std::vector<std::string> requiredParams_;
+        std::vector<std::string> requiredFields_;
+        std::optional<unsigned int> heightLevel_;
+    };
+
+    RequiredModelData requiredModelData_;    
 
 public:
     /// Default constructor.
@@ -45,15 +58,25 @@ public:
      * @param type The type of extreme event.
      */
     ExtremeEvent(const eckit::LocalConfiguration& config, const std::string& type) {
+        std::optional<unsigned int> heightLevel = std::nullopt;
         for (const auto& param : config.getSubConfigurations("required_params")) {
-            if (param.getString("type") == "atlas_field") {
-                requiredFields_.push_back(param.getString("name"));
+            // Spot configuration malformations for height levels at setup time
+            if (heightLevel.has_value() && param.has("height") && *heightLevel != param.getUnsigned("height")) {
+                throw eckit::BadValue("Several heights found for " + config.getString("name") + " event", Here());
+            }
+            if (!heightLevel.has_value() && param.has("height")) {
+                heightLevel = param.getUnsigned("height");
+            }
+            // Keep track of the required fields and parameters for validation and later retrieval during detection
+            if (param.getString("type") == "ATLAS_FIELD") {
+                requiredModelData_.requiredFields_.push_back(param.getString("name"));
             }
             else {
-                requiredParams_.push_back(param.getString("name"));
+                requiredModelData_.requiredParams_.push_back(param.getString("name"));
             }
         }
-        ASSERT_MSG(!requiredFields_.empty(),
+        requiredModelData_.heightLevel_ = heightLevel;
+        ASSERT_MSG(!requiredModelData_.requiredFields_.empty(),
                    "Event '" + type + "' has no configured required Atlas fields, detection will fail.");
     };
 
@@ -90,8 +113,9 @@ public:
     virtual std::vector<DetectionData> detect(plume::data::ModelData& modelData) = 0;
 
     /// Getters
-    const std::vector<std::string>& requiredParams() const { return requiredParams_; }
-    const std::vector<std::string>& requiredFields() const { return requiredFields_; }
+    const std::vector<std::string>& requiredParams() const { return requiredModelData_.requiredParams_; }
+    const std::vector<std::string>& requiredFields() const { return requiredModelData_.requiredFields_; }
+    const std::optional<unsigned int>& heightLevel() const { return requiredModelData_.heightLevel_; }
     virtual const std::string& type() const = 0;
 };
 

--- a/src/ee_registry/extreme_wave.cc
+++ b/src/ee_registry/extreme_wave.cc
@@ -25,7 +25,7 @@ ExtremeWave::ExtremeWave(const eckit::LocalConfiguration& config, plume::data::M
     coarseMapping_(coarseMapping),
     missingValue_(static_cast<FIELD_TYPE_REAL>(config.getInt("missing_value", 9999))) {
     // Validate that the required field is swh
-    if (requiredFields_[0] != "swh" || requiredFields_.size() > 1) {
+    if (requiredFields()[0] != "swh" || requiredFields().size() > 1) {
         throw eckit::BadValue("The 'extreme_wave' event requires the significant wave height field", Here());
     }
 
@@ -62,8 +62,8 @@ std::vector<ExtremeEvent::DetectionData> ExtremeWave::detect(plume::data::ModelD
         ee_points.push_back({{}, threshold.description, "swh", "", ""});
     }
 
-    auto fieldSwh = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getAtlasFieldShared("swh"));
-    auto halo     = atlas::array::make_view<int, 1>(modelData.getAtlasFieldShared("swh").functionspace().ghost());
+    auto fieldSwh = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getParam<atlas::Field>("swh"));
+    auto halo     = atlas::array::make_view<int, 1>(modelData.getParam<atlas::Field>("swh").functionspace().ghost());
     for (atlas::idx_t idx = 0; idx < coarseMapping_.size(); idx++) {
         // Skip the halo and missing values (over land)
         if (halo(idx) > 0 || fieldSwh(idx, 0) == missingValue_) {

--- a/src/ee_registry/extreme_wind.cc
+++ b/src/ee_registry/extreme_wind.cc
@@ -143,14 +143,14 @@ std::vector<ExtremeEvent::DetectionData> ExtremeWind::detect(plume::data::ModelD
     std::vector<DetectionData> ee_points;
     // Prepare detection outputs
     for (const auto& interval : intervals_) {
-        std::string leveltype = interval.modelLevel > 0 ? "ml" : interval.height > 0 ? "hl" : "sfc";
+        std::string levtype   = interval.modelLevel > 0 ? "ml" : interval.height > 0 ? "hl" : "sfc";
         std::string level     = interval.modelLevel > 0 ? std::to_string(interval.modelLevel)
                                 : interval.height > 0   ? std::to_string(interval.height)
-                                                        : "1";
+                                                        : "0";
         std::string param     = interval.u.empty()   ? interval.v
                                 : interval.v.empty() ? interval.u
                                                      : interval.u + "/" + interval.v;
-        ee_points.push_back({{}, interval.description, param, leveltype, level});
+        ee_points.push_back({{}, interval.description, param, levtype, level});
     }
 
     // Resolve wind fields once (same for all instances)

--- a/src/ee_registry/extreme_wind.cc
+++ b/src/ee_registry/extreme_wind.cc
@@ -9,8 +9,8 @@
  * does it submit to any jurisdiction.
  */
 #include <algorithm>
+#include <optional>
 #include <sstream>
-#include <unordered_map>
 
 #include "atlas/array.h"
 #include "atlas/field.h"
@@ -20,34 +20,42 @@
 #include "extreme_wind.h"
 
 const std::string ExtremeWind::type_                           = "extreme_wind";
-const std::array<std::string, 6> ExtremeWind::supportedFields_ = {"100u", "100v", "10u", "10v", "u", "v"};
+const std::array<std::string, 4> ExtremeWind::supportedFields_ = {"10u", "10v", "u", "v"};
 
 ExtremeWind::ExtremeWind(const eckit::LocalConfiguration& config, plume::data::ModelData& modelData,
                          const std::vector<int>& coarseMapping) :
     ExtremeEvent(config, type_), coarseMapping_(coarseMapping) {
-    // Validate that all required fields are named like wind fields
-    for (const auto& field : requiredFields_) {
+    // Validate configuration fields
+    const auto& fields = requiredFields();
+    auto hasField      = [&fields](const std::string& name) {
+        return std::find(fields.begin(), fields.end(), name) != fields.end();
+    };
+    for (const auto& field : fields) {
         if (std::find(supportedFields_.begin(), supportedFields_.end(), field) == supportedFields_.end()) {
             throw eckit::BadValue(
                 "The field '" + field +
-                    "' is not a supported wind field, please correct 'extreme_wind' event configruation.",
+                    "' is not a supported wind field, please correct 'extreme_wind' event configuration.",
                 Here());
         }
     }
+    const bool hasUv = hasField("u") || hasField("v");
+    const bool has10 = hasField("10u") || hasField("10v");
+    if (hasUv && has10) {
+        throw eckit::BadValue("Mixing surface and 3D wind fields is not supported", Here());
+    }
 
-    // Retrieve the wind intervals to run detection on and their description if applicable
-    auto findField = [this](const std::string& field) {
-        return std::find(requiredFields_.begin(), requiredFields_.end(), field) == requiredFields_.end() ? "" : field;
-    };
+    // Build detection intervals and descriptions
+    auto findField = [&hasField](const std::string& field) { return hasField(field) ? field : ""; };
 
+    const auto height = heightLevel();
     for (const auto& eventConfig : config.getSubConfigurations("instances")) {
-        if (eventConfig.isIntegralList("heights") && !eventConfig.getIntVector("heights").empty()) {
+        if (height.has_value() && eventConfig.isIntegralList("model_levels")) {
             throw eckit::BadParameter(
-                "Detecting extreme wind at given heights is not currently supported, please remove from config.");
+                "Model levels are not supported when a height is configured in required parameters", Here());
         }
 
         std::ostringstream description;
-        description << eventConfig.getString("description");
+        description << eventConfig.getString("description", "No description provided");
         if (eventConfig.getDouble("lower_bound") > eventConfig.getDouble("upper_bound")) {
             description << " (threshold : " << std::to_string(eventConfig.getDouble("lower_bound")) << " m/s)";
         }
@@ -62,12 +70,12 @@ ExtremeWind::ExtremeWind(const eckit::LocalConfiguration& config, plume::data::M
             std::string u = findField("u");
             std::string v = findField("v");
             if (u.empty() && v.empty()) {
-                throw eckit::BadParameter(
-                    "The `model_levels` key can only be used when non surface fields are required", Here());
+                throw eckit::BadParameter("The `model_levels` key can only be used when 3D fields are required",
+                                          Here());
             }
             for (const auto& ml : eventConfig.getIntVector("model_levels")) {
-                if (ml > modelData.getInt("NFLEVG")) {
-                    throw eckit::BadValue("The model has " + std::to_string(modelData.getInt("NFLEVG")) +
+                if (ml > modelData.getParam<int>("NFLEVG")) {
+                    throw eckit::BadValue("The model has " + std::to_string(modelData.getParam<int>("NFLEVG")) +
                                               " vertical levels, please adjust the config.",
                                           Here());
                 }
@@ -79,41 +87,52 @@ ExtremeWind::ExtremeWind(const eckit::LocalConfiguration& config, plume::data::M
                 else {
                     fieldDesc << "s : ('u','v'))";
                 }
-                intervals_.push_back({eventConfig.getDouble("lower_bound"), eventConfig.getDouble("upper_bound"), -1,
-                                      ml, u, v, description.str() + fieldDesc.str()});
+                intervals_.push_back({eventConfig.getDouble("lower_bound"), eventConfig.getDouble("upper_bound"), 0u,
+                                      static_cast<unsigned int>(ml), u, v, description.str() + fieldDesc.str()});
             }
         }
         else {
-            // Ensure that surface fields are provided
-            std::string u10  = findField("10u");
-            std::string v10  = findField("10v");
-            std::string u100 = findField("100u");
-            std::string v100 = findField("100v");
-            if (u10.empty() && v10.empty() && u100.empty() && v100.empty()) {
-                throw eckit::BadParameter("The `model_levels` key or surface field(s) is missing in the configuration",
-                                          Here());
+            if (height.has_value()) {
+                std::string u = findField("u");
+                std::string v = findField("v");
+                if (u.empty() && v.empty()) {
+                    throw eckit::BadParameter(
+                        "Height-based detection requires 'u' and/or 'v' fields in required parameters", Here());
+                }
+                fieldDesc.str("");
+                fieldDesc << ", height: " << std::to_string(*height) << "m, field";
+                if (u.empty() || v.empty()) {
+                    fieldDesc << " : '" << u << v << "'))";
+                }
+                else {
+                    fieldDesc << "s : ('" << u << "','" << v << "'))";
+                }
+                intervals_.push_back({eventConfig.getDouble("lower_bound"), eventConfig.getDouble("upper_bound"),
+                                      *height, 0, u, v, description.str() + fieldDesc.str()});
             }
-
-            std::vector<std::pair<std::string, std::string>> sfcWindCpnts = {{u10, v10}, {u100, v100}};
-            for (const auto& cpnt : sfcWindCpnts) {
-                if (cpnt.first.empty() && cpnt.second.empty()) {
-                    continue;
+            else {
+                // Ensure that surface fields are provided (10m wind)
+                std::string u10 = findField("10u");
+                std::string v10 = findField("10v");
+                if (u10.empty() && v10.empty()) {
+                    throw eckit::BadParameter("The `model_levels` key or 2D field(s) is missing in the configuration",
+                                              Here());
                 }
                 fieldDesc.str("");
                 fieldDesc << ", field";
-                if (cpnt.first.empty() || cpnt.second.empty()) {
-                    fieldDesc << " : '" << cpnt.first << cpnt.second << "'))";
+                if (u10.empty() || v10.empty()) {
+                    fieldDesc << " : '" << u10 << v10 << "'))";
                 }
                 else {
-                    fieldDesc << "s : ('" << cpnt.first << "','" << cpnt.second << "'))";
+                    fieldDesc << "s : ('" << u10 << "','" << v10 << "'))";
                 }
-                intervals_.push_back({eventConfig.getDouble("lower_bound"), eventConfig.getDouble("upper_bound"), -1, 0,
-                                      cpnt.first, cpnt.second, description.str() + fieldDesc.str()});
+                intervals_.push_back({eventConfig.getDouble("lower_bound"), eventConfig.getDouble("upper_bound"), 0, 0,
+                                      u10, v10, description.str() + fieldDesc.str()});
             }
         }
     }
 
-    // Ensure there is at least one instance to run detection on
+    // Final validation of interval set
     if (intervals_.empty()) {
         throw eckit::BadValue("No valid instance found for 'extreme_wind', ensure options and required fields align",
                               Here());
@@ -122,22 +141,47 @@ ExtremeWind::ExtremeWind(const eckit::LocalConfiguration& config, plume::data::M
 
 std::vector<ExtremeEvent::DetectionData> ExtremeWind::detect(plume::data::ModelData& modelData) {
     std::vector<DetectionData> ee_points;
+    // Prepare detection outputs
     for (const auto& interval : intervals_) {
-        std::string level = interval.modelLevel > 0 ? "ml" : "sfc";
-        std::string param = interval.u.empty()   ? interval.v
-                            : interval.v.empty() ? interval.u
-                                                 : interval.u + "/" + interval.v;
-        ee_points.push_back({{}, interval.description, param, level, std::to_string(interval.modelLevel)});
-    }
-    std::unordered_map<std::string, std::unique_ptr<atlas::array::ArrayView<const FIELD_TYPE_REAL, 2>>> windFields;
-    auto halo =
-        atlas::array::make_view<int, 1>(modelData.getAtlasFieldShared(requiredFields_[0]).functionspace().ghost());
-    int nbOfValues = modelData.getAtlasFieldShared(requiredFields_[0]).shape(0);
-    for (const auto& windField : requiredFields_) {
-        windFields[windField] = std::make_unique<atlas::array::ArrayView<const FIELD_TYPE_REAL, 2>>(
-            atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getAtlasFieldShared(windField)));
+        std::string levtype   = interval.modelLevel > 0 ? "ml" : interval.height > 0 ? "hl" : "sfc";
+        std::string level     = interval.modelLevel > 0 ? std::to_string(interval.modelLevel)
+                                : interval.height > 0   ? std::to_string(interval.height)
+                                                        : "0";
+        std::string param     = interval.u.empty()   ? interval.v
+                                : interval.v.empty() ? interval.u
+                                                     : interval.u + "/" + interval.v;
+        ee_points.push_back({{}, interval.description, param, levtype, level});
     }
 
+    // Resolve wind fields once (same for all instances)
+    const auto& baseInterval    = intervals_[0];
+    const std::string uName     = baseInterval.u;
+    const std::string vName     = baseInterval.v;
+    const std::string heightStr = baseInterval.height > 0 ? std::to_string(baseInterval.height) : "";
+    const bool hasU             = !uName.empty();
+    const bool hasV             = !vName.empty();
+
+    std::optional<atlas::Field> uField;
+    std::optional<atlas::Field> vField;
+    std::optional<atlas::array::ArrayView<const FIELD_TYPE_REAL, 2>> uView;
+    std::optional<atlas::array::ArrayView<const FIELD_TYPE_REAL, 2>> vView;
+
+    if (hasU) {
+        uField = baseInterval.height > 0 ? modelData.getParam<atlas::Field>(uName, heightStr)
+                                         : modelData.getParam<atlas::Field>(uName);
+        uView  = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(*uField);
+    }
+    if (hasV) {
+        vField = baseInterval.height > 0 ? modelData.getParam<atlas::Field>(vName, heightStr)
+                                         : modelData.getParam<atlas::Field>(vName);
+        vView  = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(*vField);
+    }
+
+    const atlas::Field& baseField = hasU ? *uField : *vField;
+    auto halo                     = atlas::array::make_view<int, 1>(baseField.functionspace().ghost());
+    int nbOfValues                = baseField.shape(0);
+
+    // Run detection across grid points
     for (atlas::idx_t idx = 0; idx < nbOfValues; idx++) {
         // Skip the halo
         if (halo(idx) > 0) {
@@ -146,16 +190,13 @@ std::vector<ExtremeEvent::DetectionData> ExtremeWind::detect(plume::data::ModelD
 
         for (size_t idx_int = 0; idx_int < intervals_.size(); idx_int++) {
             // Skip detection if the coarse cell has already fired
-            // TODO: is this condition worth adding because it adds an operation for each non firing point ?
             if (ee_points[idx_int].detectedCells.find(coarseMapping_[idx]) != ee_points[idx_int].detectedCells.end()) {
                 continue;
             }
             // If it is not a surface field we remove 1 from the index as model levels start at 1 and not 0
-            int levelIdx = intervals_[idx_int].modelLevel > 0 ? intervals_[idx_int].modelLevel - 1 : 0;
-            FIELD_TYPE_REAL valU =
-                intervals_[idx_int].u.empty() ? 0 : (*windFields[intervals_[idx_int].u])(idx, levelIdx);
-            FIELD_TYPE_REAL valV =
-                intervals_[idx_int].v.empty() ? 0 : (*windFields[intervals_[idx_int].v])(idx, levelIdx);
+            int levelIdx                  = intervals_[idx_int].modelLevel > 0 ? intervals_[idx_int].modelLevel - 1 : 0;
+            FIELD_TYPE_REAL valU          = hasU ? (*uView)(idx, levelIdx) : 0;
+            FIELD_TYPE_REAL valV          = hasV ? (*vView)(idx, levelIdx) : 0;
             FIELD_TYPE_REAL windMagnitude = std::sqrt(valU * valU + valV * valV);
             if (windMagnitude < intervals_[idx_int].lBound) {
                 continue;

--- a/src/ee_registry/extreme_wind.cc
+++ b/src/ee_registry/extreme_wind.cc
@@ -9,8 +9,8 @@
  * does it submit to any jurisdiction.
  */
 #include <algorithm>
+#include <optional>
 #include <sstream>
-#include <unordered_map>
 
 #include "atlas/array.h"
 #include "atlas/field.h"
@@ -20,34 +20,42 @@
 #include "extreme_wind.h"
 
 const std::string ExtremeWind::type_                           = "extreme_wind";
-const std::array<std::string, 6> ExtremeWind::supportedFields_ = {"100u", "100v", "10u", "10v", "u", "v"};
+const std::array<std::string, 4> ExtremeWind::supportedFields_ = {"10u", "10v", "u", "v"};
 
 ExtremeWind::ExtremeWind(const eckit::LocalConfiguration& config, plume::data::ModelData& modelData,
                          const std::vector<int>& coarseMapping) :
     ExtremeEvent(config, type_), coarseMapping_(coarseMapping) {
-    // Validate that all required fields are named like wind fields
-    for (const auto& field : requiredFields_) {
+    // Validate configuration fields
+    const auto& fields = requiredFields();
+    auto hasField      = [&fields](const std::string& name) {
+        return std::find(fields.begin(), fields.end(), name) != fields.end();
+    };
+    for (const auto& field : fields) {
         if (std::find(supportedFields_.begin(), supportedFields_.end(), field) == supportedFields_.end()) {
             throw eckit::BadValue(
                 "The field '" + field +
-                    "' is not a supported wind field, please correct 'extreme_wind' event configruation.",
+                    "' is not a supported wind field, please correct 'extreme_wind' event configuration.",
                 Here());
         }
     }
+    const bool hasUv = hasField("u") || hasField("v");
+    const bool has10 = hasField("10u") || hasField("10v");
+    if (hasUv && has10) {
+        throw eckit::BadValue("Mixing surface and 3D wind fields is not supported", Here());
+    }
 
-    // Retrieve the wind intervals to run detection on and their description if applicable
-    auto findField = [this](const std::string& field) {
-        return std::find(requiredFields_.begin(), requiredFields_.end(), field) == requiredFields_.end() ? "" : field;
-    };
+    // Build detection intervals and descriptions
+    auto findField = [&hasField](const std::string& field) { return hasField(field) ? field : ""; };
 
+    const auto height = heightLevel();
     for (const auto& eventConfig : config.getSubConfigurations("instances")) {
-        if (eventConfig.isIntegralList("heights") && !eventConfig.getIntVector("heights").empty()) {
+        if (height.has_value() && eventConfig.isIntegralList("model_levels")) {
             throw eckit::BadParameter(
-                "Detecting extreme wind at given heights is not currently supported, please remove from config.");
+                "Model levels are not supported when a height is configured in required parameters", Here());
         }
 
         std::ostringstream description;
-        description << eventConfig.getString("description");
+        description << eventConfig.getString("description", "No description provided");
         if (eventConfig.getDouble("lower_bound") > eventConfig.getDouble("upper_bound")) {
             description << " (threshold : " << std::to_string(eventConfig.getDouble("lower_bound")) << " m/s)";
         }
@@ -62,12 +70,12 @@ ExtremeWind::ExtremeWind(const eckit::LocalConfiguration& config, plume::data::M
             std::string u = findField("u");
             std::string v = findField("v");
             if (u.empty() && v.empty()) {
-                throw eckit::BadParameter(
-                    "The `model_levels` key can only be used when non surface fields are required", Here());
+                throw eckit::BadParameter("The `model_levels` key can only be used when 3D fields are required",
+                                          Here());
             }
             for (const auto& ml : eventConfig.getIntVector("model_levels")) {
-                if (ml > modelData.getInt("NFLEVG")) {
-                    throw eckit::BadValue("The model has " + std::to_string(modelData.getInt("NFLEVG")) +
+                if (ml > modelData.getParam<int>("NFLEVG")) {
+                    throw eckit::BadValue("The model has " + std::to_string(modelData.getParam<int>("NFLEVG")) +
                                               " vertical levels, please adjust the config.",
                                           Here());
                 }
@@ -79,41 +87,52 @@ ExtremeWind::ExtremeWind(const eckit::LocalConfiguration& config, plume::data::M
                 else {
                     fieldDesc << "s : ('u','v'))";
                 }
-                intervals_.push_back({eventConfig.getDouble("lower_bound"), eventConfig.getDouble("upper_bound"), -1,
-                                      ml, u, v, description.str() + fieldDesc.str()});
+                intervals_.push_back({eventConfig.getDouble("lower_bound"), eventConfig.getDouble("upper_bound"), 0u,
+                                      static_cast<unsigned int>(ml), u, v, description.str() + fieldDesc.str()});
             }
         }
         else {
-            // Ensure that surface fields are provided
-            std::string u10  = findField("10u");
-            std::string v10  = findField("10v");
-            std::string u100 = findField("100u");
-            std::string v100 = findField("100v");
-            if (u10.empty() && v10.empty() && u100.empty() && v100.empty()) {
-                throw eckit::BadParameter("The `model_levels` key or surface field(s) is missing in the configuration",
-                                          Here());
+            if (height.has_value()) {
+                std::string u = findField("u");
+                std::string v = findField("v");
+                if (u.empty() && v.empty()) {
+                    throw eckit::BadParameter(
+                        "Height-based detection requires 'u' and/or 'v' fields in required parameters", Here());
+                }
+                fieldDesc.str("");
+                fieldDesc << ", height: " << std::to_string(*height) << "m, field";
+                if (u.empty() || v.empty()) {
+                    fieldDesc << " : '" << u << v << "'))";
+                }
+                else {
+                    fieldDesc << "s : ('" << u << "','" << v << "'))";
+                }
+                intervals_.push_back({eventConfig.getDouble("lower_bound"), eventConfig.getDouble("upper_bound"),
+                                      *height, 0, u, v, description.str() + fieldDesc.str()});
             }
-
-            std::vector<std::pair<std::string, std::string>> sfcWindCpnts = {{u10, v10}, {u100, v100}};
-            for (const auto& cpnt : sfcWindCpnts) {
-                if (cpnt.first.empty() && cpnt.second.empty()) {
-                    continue;
+            else {
+                // Ensure that surface fields are provided (10m wind)
+                std::string u10 = findField("10u");
+                std::string v10 = findField("10v");
+                if (u10.empty() && v10.empty()) {
+                    throw eckit::BadParameter("The `model_levels` key or 2D field(s) is missing in the configuration",
+                                              Here());
                 }
                 fieldDesc.str("");
                 fieldDesc << ", field";
-                if (cpnt.first.empty() || cpnt.second.empty()) {
-                    fieldDesc << " : '" << cpnt.first << cpnt.second << "'))";
+                if (u10.empty() || v10.empty()) {
+                    fieldDesc << " : '" << u10 << v10 << "'))";
                 }
                 else {
-                    fieldDesc << "s : ('" << cpnt.first << "','" << cpnt.second << "'))";
+                    fieldDesc << "s : ('" << u10 << "','" << v10 << "'))";
                 }
-                intervals_.push_back({eventConfig.getDouble("lower_bound"), eventConfig.getDouble("upper_bound"), -1, 0,
-                                      cpnt.first, cpnt.second, description.str() + fieldDesc.str()});
+                intervals_.push_back({eventConfig.getDouble("lower_bound"), eventConfig.getDouble("upper_bound"), 0, 0,
+                                      u10, v10, description.str() + fieldDesc.str()});
             }
         }
     }
 
-    // Ensure there is at least one instance to run detection on
+    // Final validation of interval set
     if (intervals_.empty()) {
         throw eckit::BadValue("No valid instance found for 'extreme_wind', ensure options and required fields align",
                               Here());
@@ -122,22 +141,47 @@ ExtremeWind::ExtremeWind(const eckit::LocalConfiguration& config, plume::data::M
 
 std::vector<ExtremeEvent::DetectionData> ExtremeWind::detect(plume::data::ModelData& modelData) {
     std::vector<DetectionData> ee_points;
+    // Prepare detection outputs
     for (const auto& interval : intervals_) {
-        std::string level = interval.modelLevel > 0 ? "ml" : "sfc";
-        std::string param = interval.u.empty()   ? interval.v
-                            : interval.v.empty() ? interval.u
-                                                 : interval.u + "/" + interval.v;
-        ee_points.push_back({{}, interval.description, param, level, std::to_string(interval.modelLevel)});
-    }
-    std::unordered_map<std::string, std::unique_ptr<atlas::array::ArrayView<const FIELD_TYPE_REAL, 2>>> windFields;
-    auto halo =
-        atlas::array::make_view<int, 1>(modelData.getAtlasFieldShared(requiredFields_[0]).functionspace().ghost());
-    int nbOfValues = modelData.getAtlasFieldShared(requiredFields_[0]).shape(0);
-    for (const auto& windField : requiredFields_) {
-        windFields[windField] = std::make_unique<atlas::array::ArrayView<const FIELD_TYPE_REAL, 2>>(
-            atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getAtlasFieldShared(windField)));
+        std::string leveltype = interval.modelLevel > 0 ? "ml" : interval.height > 0 ? "hl" : "sfc";
+        std::string level     = interval.modelLevel > 0 ? std::to_string(interval.modelLevel)
+                                : interval.height > 0   ? std::to_string(interval.height)
+                                                        : "1";
+        std::string param     = interval.u.empty()   ? interval.v
+                                : interval.v.empty() ? interval.u
+                                                     : interval.u + "/" + interval.v;
+        ee_points.push_back({{}, interval.description, param, leveltype, level});
     }
 
+    // Resolve wind fields once (same for all instances)
+    const auto& baseInterval    = intervals_[0];
+    const std::string uName     = baseInterval.u;
+    const std::string vName     = baseInterval.v;
+    const std::string heightStr = baseInterval.height > 0 ? std::to_string(baseInterval.height) : "";
+    const bool hasU             = !uName.empty();
+    const bool hasV             = !vName.empty();
+
+    std::optional<atlas::Field> uField;
+    std::optional<atlas::Field> vField;
+    std::optional<atlas::array::ArrayView<const FIELD_TYPE_REAL, 2>> uView;
+    std::optional<atlas::array::ArrayView<const FIELD_TYPE_REAL, 2>> vView;
+
+    if (hasU) {
+        uField = baseInterval.height > 0 ? modelData.getParam<atlas::Field>(uName, heightStr)
+                                         : modelData.getParam<atlas::Field>(uName);
+        uView  = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(*uField);
+    }
+    if (hasV) {
+        vField = baseInterval.height > 0 ? modelData.getParam<atlas::Field>(vName, heightStr)
+                                         : modelData.getParam<atlas::Field>(vName);
+        vView  = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(*vField);
+    }
+
+    const atlas::Field& baseField = hasU ? *uField : *vField;
+    auto halo                     = atlas::array::make_view<int, 1>(baseField.functionspace().ghost());
+    int nbOfValues                = baseField.shape(0);
+
+    // Run detection across grid points
     for (atlas::idx_t idx = 0; idx < nbOfValues; idx++) {
         // Skip the halo
         if (halo(idx) > 0) {
@@ -146,16 +190,13 @@ std::vector<ExtremeEvent::DetectionData> ExtremeWind::detect(plume::data::ModelD
 
         for (size_t idx_int = 0; idx_int < intervals_.size(); idx_int++) {
             // Skip detection if the coarse cell has already fired
-            // TODO: is this condition worth adding because it adds an operation for each non firing point ?
             if (ee_points[idx_int].detectedCells.find(coarseMapping_[idx]) != ee_points[idx_int].detectedCells.end()) {
                 continue;
             }
             // If it is not a surface field we remove 1 from the index as model levels start at 1 and not 0
-            int levelIdx = intervals_[idx_int].modelLevel > 0 ? intervals_[idx_int].modelLevel - 1 : 0;
-            FIELD_TYPE_REAL valU =
-                intervals_[idx_int].u.empty() ? 0 : (*windFields[intervals_[idx_int].u])(idx, levelIdx);
-            FIELD_TYPE_REAL valV =
-                intervals_[idx_int].v.empty() ? 0 : (*windFields[intervals_[idx_int].v])(idx, levelIdx);
+            int levelIdx                  = intervals_[idx_int].modelLevel > 0 ? intervals_[idx_int].modelLevel - 1 : 0;
+            FIELD_TYPE_REAL valU          = hasU ? (*uView)(idx, levelIdx) : 0;
+            FIELD_TYPE_REAL valV          = hasV ? (*vView)(idx, levelIdx) : 0;
             FIELD_TYPE_REAL windMagnitude = std::sqrt(valU * valU + valV * valV);
             if (windMagnitude < intervals_[idx_int].lBound) {
                 continue;

--- a/src/ee_registry/extreme_wind.h
+++ b/src/ee_registry/extreme_wind.h
@@ -26,17 +26,16 @@
 class ExtremeWind final : public ExtremeEvent {
 private:
     static const std::string type_;
-    static const std::array<std::string, 6> supportedFields_;
+    static const std::array<std::string, 4> supportedFields_;
 
     /**
      * @brief Represents the wind thresholds to run detection on.
      *
      * A description can be provided for communicating results in a human-friendly fashion.
-     * @todo Implement support for height.
      */
     struct Interval {
         double lBound, uBound;
-        int height, modelLevel;
+        unsigned int height, modelLevel;
         std::string u, v, description;
     };
 
@@ -48,8 +47,7 @@ public:
      * @brief Constructs an extreme wind event.
      *
      * The plugin does not validate that the configured fields are indeed representing winds, but it enforces
-     * the use of either the surface fields {10,100}{u,v} or the leveled fields {u,v}.
-     * @warning Detection at given heights when levels are provided is not supported yet.
+     * the use of either the surface fields {10}{u,v} or the leveled fields {u,v} (on height or model levels).
      *
      * @param config The configuration of the event, mainly consisting of parameters for bounds, description, and height
      *        for several instances.

--- a/src/ee_registry/ramp.cc
+++ b/src/ee_registry/ramp.cc
@@ -39,14 +39,20 @@ RampEvent::RampEvent(const eckit::LocalConfiguration& config, plume::data::Model
     }
 
     timeWindow_     = config.getUnsigned("time_window");
-    ntimeSteps_     = std::ceil(timeWindow_ * 60 / modelData.getDouble("TSTEP"));
+    ntimeSteps_     = std::ceil(timeWindow_ * 60 / modelData.getParam<double>("TSTEP"));
     previousValues_ = std::deque<FIELD_TYPE_REAL>(ntimeSteps_ * coarseMapping_.size(), 0);
-
-    std::ostringstream fieldVec;
-    for (size_t i = 0; i < requiredFields_.size() - 1; i++) {
-        fieldVec << requiredFields_[i] << "/";
+    if (heightLevel().has_value()) {
+        levtype_ = "hl";
+        level_   = std::to_string(*heightLevel());
     }
-    fieldVec << requiredFields_[requiredFields_.size() - 1];
+
+    const auto& fields      = requiredFields();
+    const size_t fieldCount = fields.size();
+    std::ostringstream fieldVec;
+    for (size_t i = 0; i + 1 < fieldCount; i++) {
+        fieldVec << fields[i] << "/";
+    }
+    fieldVec << fields[fieldCount - 1];
     fieldNamesStr_ = fieldVec.str();
     if (rampUp_) {
         descriptionUp_ = "Ramp up of " + config.getString("ramp_up_value") + " over " +
@@ -60,35 +66,42 @@ RampEvent::RampEvent(const eckit::LocalConfiguration& config, plume::data::Model
 
 std::vector<ExtremeEvent::DetectionData> RampEvent::detect(plume::data::ModelData& modelData) {
     std::vector<DetectionData> ee_points;
-    std::vector<atlas::array::ArrayView<const FIELD_TYPE_REAL, 2>> fields;
-    for (const auto& field : requiredFields_) {
-        fields.push_back(atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getAtlasFieldShared(field)));
+    const auto& fields = requiredFields();
+    std::vector<atlas::array::ArrayView<const FIELD_TYPE_REAL, 2>> arrayViews;
+    arrayViews.reserve(fields.size());
+    const auto height          = heightLevel();
+    const std::string levelStr = height.has_value() ? std::to_string(*height) : "";
+    for (const auto& fieldName : fields) {
+        auto field = height.has_value() ? modelData.getParam<atlas::Field>(fieldName, levelStr)
+                                            : modelData.getParam<atlas::Field>(fieldName);
+        arrayViews.push_back(atlas::array::make_view<const FIELD_TYPE_REAL, 2>(field));
     }
-    auto halo
-        = atlas::array::make_view<int, 1>(modelData.getAtlasFieldShared(requiredFields_[0]).functionspace().ghost());
+    auto haloField = height.has_value() ? modelData.getParam<atlas::Field>(fields[0], levelStr)
+                                        : modelData.getParam<atlas::Field>(fields[0]);
+    auto halo      = atlas::array::make_view<int, 1>(haloField.functionspace().ghost());
     // 1. Slide the values window with current time step values
     previousValues_.erase(previousValues_.begin() + (ntimeSteps_ - 1) * coarseMapping_.size(), previousValues_.end());
     // reverse inserting element to maintain indices
     for (atlas::idx_t idx = coarseMapping_.size() - 1; idx >= 0; idx--) {
         if (halo(idx) > 0) {
-            previousValues_.push_front(0); // Add values with no effect in the halo
+            previousValues_.push_front(0);  // Add values with no effect in the halo
         }
 
         // If several parameters are given, the magnitude is computed as the value, it is the user's responsibility
         // to ensure this quantity makes sense, and the passed fields are 2D (or run detection on level 1)
-        if (fields.size() > 1) {
+        if (arrayViews.size() > 1) {
             FIELD_TYPE_REAL squareMag = 0;
-            for (const auto& field : fields) {
+            for (const auto& field : arrayViews) {
                 squareMag += field(idx, 0) * field(idx, 0);
             }
             previousValues_.push_front(std::sqrt(squareMag));
         }
         else {
-            previousValues_.push_front(fields[0](idx, 0));
+            previousValues_.push_front(arrayViews[0](idx, 0));
         }
-    }    
+    }
 
-    if (modelData.getInt("NSTEP") < ntimeSteps_) {  // Fill the previous values array but do not run detection yet
+    if (modelData.getParam<int>("NSTEP") < ntimeSteps_) {  // Fill the current step array but do not run detection yet
         return ee_points;
     }
 
@@ -116,8 +129,8 @@ std::vector<ExtremeEvent::DetectionData> RampEvent::detect(plume::data::ModelDat
         }
     }
 
-    ee_points.push_back({{}, descriptionUp_, fieldNamesStr_, "sfc", "0"});
-    ee_points.push_back({{}, descriptionDown_, fieldNamesStr_, "sfc", "0"});
+    ee_points.push_back({{}, descriptionUp_, fieldNamesStr_, levtype_, level_});
+    ee_points.push_back({{}, descriptionDown_, fieldNamesStr_, levtype_, level_});
     for (const auto& [cell, max] : cellMaxima) {
         if (max > rampUpValue_) {
             ee_points[0].detectedCells.insert(cell);

--- a/src/ee_registry/ramp.h
+++ b/src/ee_registry/ramp.h
@@ -29,6 +29,8 @@ private:
     std::string descriptionUp_;
     std::string descriptionDown_;
     std::string fieldNamesStr_;
+    std::string levtype_ = "sfc";
+    std::string level_ = "0";
 
     unsigned int timeWindow_;
     size_t ntimeSteps_;

--- a/src/ee_registry/storm.cc
+++ b/src/ee_registry/storm.cc
@@ -26,44 +26,70 @@ const std::string Storm::type_ = "storm";
 Storm::Storm(const eckit::LocalConfiguration& config, plume::data::ModelData& modelData,
              const std::vector<int>& coarseMapping) :
     ExtremeEvent(config, type_), coarseMapping_(coarseMapping) {
-    std::sort(requiredFields_.begin(), requiredFields_.end());
-    /** @todo 100u and 100v will not exist after the GRIB2 migration, the event will need a refactor with an updated
-     *        Plume interface to access levtype 'hl' and level '100', or it can use the levtype 'ml' and compute the
-     *        height from the geopotential.
-     */
-    if (requiredFields_ != std::vector<std::string>{"100u", "100v"}) {
-        throw eckit::BadValue("Storm requires 100m wind component fields.", Here());
+    const auto& fields = requiredFields();
+    const bool hasU    = std::find(fields.begin(), fields.end(), "u") != fields.end();
+    const bool hasV    = std::find(fields.begin(), fields.end(), "v") != fields.end();
+    if (!hasU || !hasV) {
+        throw eckit::BadValue("Storm requires two components of wind fields.", Here());
     }
     windSpeedCutout_ = static_cast<FIELD_TYPE_REAL>(config.getDouble("wind_speed_cutout"));
     if (windSpeedCutout_ < 0) {
         throw eckit::BadValue("The cutout wind speed for the storm event should be positive", Here());
     }
 
-    timeWindow_      = config.getUnsigned("time_window");
-    ntimeSteps_      = std::ceil(timeWindow_ * 60 / modelData.getDouble("TSTEP"));
-    windSpeeds_      = std::deque<FIELD_TYPE_REAL>(ntimeSteps_ * coarseMapping_.size(), 0);
-    description_     = "Storm (100m wind speed average over " + config.getString("time_window") + "min exceeding " +
-                   config.getString("wind_speed_cutout") + "m/s)";
+    levtype_ = config.has("model_level") ? "ml" : "hl";
+    level_   = heightLevel().value_or(config.getUnsigned("model_level", 1));
+    // There is no need for height check as Plume update strategy will already have validated it, unless an event has a
+    // specific height cap it needs to enforce.
+    if (levtype_ == "ml" && level_ > modelData.getParam<int>("NFLEVG")) {
+        throw eckit::BadValue(
+            "The specified level for the storm event is higher than the number of levels in the model", Here());
+    }
+    std::string levelString = levtype_ == "ml" ? "ml " + std::to_string(level_) : std::to_string(level_) + "m";
+
+    timeWindow_  = config.getUnsigned("time_window");
+    ntimeSteps_  = std::ceil(timeWindow_ * 60 / modelData.getParam<double>("TSTEP"));
+    windSpeeds_  = std::deque<FIELD_TYPE_REAL>(ntimeSteps_ * coarseMapping_.size(), 0);
+    description_ = "Storm (wind speed average over " + config.getString("time_window") + "min exceeding " +
+                   config.getString("wind_speed_cutout") + "m/s at " + levelString + ")";
 }
 
 std::vector<ExtremeEvent::DetectionData> Storm::detect(plume::data::ModelData& modelData) {
     std::vector<DetectionData> ee_points;
-    auto fieldU = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getAtlasFieldShared("100u"));
-    auto fieldV = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getAtlasFieldShared("100v"));
-    auto halo = atlas::array::make_view<int, 1>(modelData.getAtlasFieldShared("100u").functionspace().ghost());
-    // 1. Slide the wind speeds window with current time step values
+
+    // 1. Slide the wind speeds window with current time step values, support for both ml (3D) and hl (2D)
+    auto slideWindSpeeds = [&](const auto& u, const auto& v, const auto& halo, auto accessor) {
+        // reverse inserting element to maintain indices
+        for (atlas::idx_t idx = coarseMapping_.size() - 1; idx >= 0; idx--) {
+            if (halo(idx) > 0) {
+                windSpeeds_.push_front(0);  // Add values with no effect for halo points
+            }
+            else {
+                windSpeeds_.push_front(
+                    std::sqrt(accessor(u, idx) * accessor(u, idx) + accessor(v, idx) * accessor(v, idx)));
+            }
+        }
+    };
     windSpeeds_.erase(windSpeeds_.begin() + (ntimeSteps_ - 1) * coarseMapping_.size(), windSpeeds_.end());
-    // reverse inserting element to maintain indices
-    for (atlas::idx_t idx = coarseMapping_.size() - 1; idx >= 0; idx--) {
-        if (halo(idx) > 0) {
-            windSpeeds_.push_front(0); // Add values with no effect for halo points
-        }
-        else {
-            windSpeeds_.push_front(std::sqrt(fieldU(idx, 0) * fieldU(idx, 0) + fieldV(idx, 0) * fieldV(idx, 0)));
-        }
+
+    if (levtype_ == "ml") {
+        auto halo = atlas::array::make_view<int, 1>(modelData.getParam<atlas::Field>("u").functionspace().ghost());
+        auto u = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getParam<atlas::Field>("u"));
+        auto v = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getParam<atlas::Field>("v"));
+        // Model levels are 1-indexed in the input files but 0-indexed in the code, hence the -1
+        slideWindSpeeds(u, v, halo, [this](const auto& field, atlas::idx_t idx) { return field(idx, level_ - 1); });
     }
-    
-    if (modelData.getInt("NSTEP") < ntimeSteps_) {  // Fill the wind speed array but do not run detection yet
+    else {
+        // (wind at) height levels are 2D fields (3D fields with a single level owned by Plume)
+        auto uField = modelData.getParam<atlas::Field>("u", std::to_string(level_));
+        auto vField = modelData.getParam<atlas::Field>("v", std::to_string(level_));
+        auto halo = atlas::array::make_view<int, 1>(uField.functionspace().ghost());
+        auto u = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(uField);
+        auto v = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(vField);
+        slideWindSpeeds(u, v, halo, [this](const auto& field, atlas::idx_t idx) { return field(idx, 0); });
+    }
+    // Fill the wind speed array but do not run detection yet
+    if (modelData.getParam<int>("NSTEP") < ntimeSteps_) {
         return ee_points;
     }
 
@@ -83,10 +109,8 @@ std::vector<ExtremeEvent::DetectionData> Storm::detect(plume::data::ModelData& m
         }
     }
 
-    /** @todo Extremes DT output these fields as levtype 'hl' levelist '100', the keys will need an update for
-     *        GRIB2 compatibility. Ideally it is fetched from Plume or the field metadata instead of being hardcoded.
-     */
-    ee_points.push_back({{}, description_, "100u/100v", "sfc", "0"});
+    // 3. Build the detection result with the cell indices that exceed the cutout value
+    ee_points.push_back({{}, description_, "u/v", levtype_, std::to_string(level_)});
     for (const auto& [cell, max] : cellMaximums) {
         if (max > windSpeedCutout_) {
             ee_points[0].detectedCells.insert(cell);

--- a/src/ee_registry/storm.h
+++ b/src/ee_registry/storm.h
@@ -32,6 +32,9 @@ private:
     unsigned int timeWindow_;
     size_t ntimeSteps_;
 
+    /// The height at which the event is detected, model level is used if not specified (defaults to 1)
+    unsigned int level_;
+    std::string levtype_;
     FIELD_TYPE_REAL windSpeedCutout_;
     /**
      * This array stores the wind speeds of the original grid points.
@@ -51,7 +54,6 @@ public:
      * The values are stored as doubles or floats to maintain the full precision, but there is a commit with a version
      * of this event using 2-byte integers, as the wind can safely be represented on uint16_t if only two decimals of
      * precision are kept.
-     * @warning Only GRIB1 fields 100u and 100v are used in this event for now. It will be migrated to GRIB2 later on.
      *
      * @param config The configuration of the event, mainly consisting of parameters for cutout speed and time window.
      * @param modelData The model data passed through Plume.
@@ -63,7 +65,8 @@ public:
     /**
      * @brief Detects storms using the definition below.
      *
-     * This event checks if the 100m wind speed exceeds a configured threshold over a configured time window.
+     * This event checks if the wind speed at a configured height or model level exceeds a configured threshold over a
+     * configured time window.
      * Each coarse cell value is the maximum value of the temporal average of its original grid points.
      *
      * @param modelData The model data that contains the wind fields to run detection on.

--- a/src/ee_registry/wind_drought.cc
+++ b/src/ee_registry/wind_drought.cc
@@ -8,8 +8,10 @@
  * granted to it by virtue of its status as an intergovernmental organisation nor
  * does it submit to any jurisdiction.
  */
+#include <algorithm>
 #include <cmath>
 
+#include "atlas/field.h"
 #include "atlas/functionspace.h"
 #include "eckit/exception/Exceptions.h"
 
@@ -20,51 +22,65 @@ const std::string WindDrought::type_ = "wind_drought";
 WindDrought::WindDrought(const eckit::LocalConfiguration& config, plume::data::ModelData& modelData,
                          const std::vector<int>& coarseMapping) :
     ExtremeEvent(config, type_), coarseMapping_(coarseMapping) {
-    std::sort(requiredFields_.begin(), requiredFields_.end());
-    /** @todo 100u and 100v will not exist after the GRIB2 migration, the event will need a refactor with an updated
-     *        Plume interface to access levtype 'hl' and level '100', or it can use the levtype 'ml' and compute the
-     *        height from the geopotential.
-     */
-    if (requiredFields_ != std::vector<std::string>{"100u", "100v"}) {
-        throw eckit::BadValue("Wind drought event requires 100m wind component fields.", Here());
+
+    const auto& fields = requiredFields();
+    const bool hasU    = std::find(fields.begin(), fields.end(), "u") != fields.end();
+    const bool hasV    = std::find(fields.begin(), fields.end(), "v") != fields.end();
+    if (!hasU || !hasV) {
+        throw eckit::BadValue("Wind drought requires wind component fields 'u' and 'v'.", Here());
     }
+
     windSpeedCutout_ = static_cast<FIELD_TYPE_REAL>(config.getDouble("wind_speed_cutout"));
     if (windSpeedCutout_ < 0) {
         throw eckit::BadValue("The cutout wind magnitude for the wind drought event should be greater than 0", Here());
     }
 
     windDroughtSteps_.assign(coarseMapping_.size(), 0);
-    timeWindow_  = config.getUnsigned("time_window");
-    ntimeSteps_  = std::ceil(timeWindow_ * 60 / modelData.getDouble("TSTEP"));
-    description_ = "Wind drought (100m wind speed remains below " + config.getString("wind_speed_cutout") +
-                   "m/s for over " + config.getString("time_window") + "minutes)";
+    timeWindow_                   = config.getUnsigned("time_window");
+    ntimeSteps_                   = std::ceil(timeWindow_ * 60 / modelData.getParam<double>("TSTEP"));
+    const bool useHeight          = heightLevel().has_value();
+    const unsigned int modelLevel = config.getUnsigned("model_level", 1);
+    levtype_                      = useHeight ? "hl" : "ml";
+    level_                        = useHeight ? std::to_string(*heightLevel()) : std::to_string(modelLevel);
+    if (!useHeight && modelLevel > modelData.getParam<int>("NFLEVG")) {
+        throw eckit::BadValue(
+            "The specified level for the wind drought event is higher than the number of levels in the model", Here());
+    }
+    const std::string levelStr = useHeight ? level_ + "m" : "ml " + level_;
+    description_ = "Wind drought (wind speed remains below " + config.getString("wind_speed_cutout") + "m/s for over " +
+                   config.getString("time_window") + "minutes at " + levelStr + ")";
 }
 
 std::vector<ExtremeEvent::DetectionData> WindDrought::detect(plume::data::ModelData& modelData) {
     std::vector<DetectionData> ee_points;
-    auto fieldU = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getAtlasFieldShared("100u"));
-    auto fieldV = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getAtlasFieldShared("100v"));
-    auto halo = atlas::array::make_view<int, 1>(modelData.getAtlasFieldShared("100u").functionspace().ghost());
+    const bool useHeight = levtype_ == "hl";
+
+    auto uField = useHeight ? modelData.getParam<atlas::Field>("u", level_) : modelData.getParam<atlas::Field>("u");
+    auto vField = useHeight ? modelData.getParam<atlas::Field>("v", level_) : modelData.getParam<atlas::Field>("v");
+    auto arrayU = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(uField);
+    auto arrayV = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(vField);
+    auto halo   = atlas::array::make_view<int, 1>(uField.functionspace().ghost());
+    const int levelIdx = useHeight ? 0 : std::stoi(level_) - 1;
+
     // 1. Compute spatial wind speed average & update count for each cell
     for (atlas::idx_t idx = 0; idx < coarseMapping_.size(); idx++) {
         if (halo(idx) > 0) {
-            continue; // Halo counters stay at 0 so they have no effect
+            continue;  // Halo counters stay at 0 so they have no effect
         }
 
-        FIELD_TYPE_REAL windMagnitude = std::sqrt(fieldU(idx, 0) * fieldU(idx, 0) + fieldV(idx, 0) * fieldV(idx, 0));
+        FIELD_TYPE_REAL valU          = arrayU(idx, levelIdx);
+        FIELD_TYPE_REAL valV          = arrayV(idx, levelIdx);
+        FIELD_TYPE_REAL windMagnitude = std::sqrt(valU * valU + valV * valV);
         if (windMagnitude < windSpeedCutout_) {
             ++windDroughtSteps_[idx];
         }
         else {
-            windDroughtSteps_[idx] = 0; // This resets the counter if the wind finally exceeds the threshold
+            windDroughtSteps_[idx] = 0;  // This resets the counter if the wind finally exceeds the threshold
         }
     }
 
     // 2. Detect the cells that have not exceeded the wind threshold during the time window
-    /** @todo Extremes DT output these fields as levtype 'hl' levelist '100', the keys will need an update for
-     *        GRIB2 compatibility. Ideally it is fetched from Plume or the field metadata instead of being hardcoded.
-     */
-    ee_points.push_back({{}, description_, "100u/100v", "sfc", "0"});
+    ee_points.push_back({{}, description_, "u/v", levtype_, level_});
     for (atlas::idx_t idx = 0; idx < coarseMapping_.size(); idx++) {
         if (ntimeSteps_ < windDroughtSteps_[idx]) {
             ee_points[0].detectedCells.insert(coarseMapping_[idx]);

--- a/src/ee_registry/wind_drought.cc
+++ b/src/ee_registry/wind_drought.cc
@@ -8,8 +8,10 @@
  * granted to it by virtue of its status as an intergovernmental organisation nor
  * does it submit to any jurisdiction.
  */
+#include <algorithm>
 #include <cmath>
 
+#include "atlas/field.h"
 #include "atlas/functionspace.h"
 #include "eckit/exception/Exceptions.h"
 
@@ -20,51 +22,65 @@ const std::string WindDrought::type_ = "wind_drought";
 WindDrought::WindDrought(const eckit::LocalConfiguration& config, plume::data::ModelData& modelData,
                          const std::vector<int>& coarseMapping) :
     ExtremeEvent(config, type_), coarseMapping_(coarseMapping) {
-    std::sort(requiredFields_.begin(), requiredFields_.end());
-    /** @todo 100u and 100v will not exist after the GRIB2 migration, the event will need a refactor with an updated
-     *        Plume interface to access levtype 'hl' and level '100', or it can use the levtype 'ml' and compute the
-     *        height from the geopotential.
-     */
-    if (requiredFields_ != std::vector<std::string>{"100u", "100v"}) {
-        throw eckit::BadValue("Wind drought event requires 100m wind component fields.", Here());
+
+    const auto& fields = requiredFields();
+    const bool hasU    = std::find(fields.begin(), fields.end(), "u") != fields.end();
+    const bool hasV    = std::find(fields.begin(), fields.end(), "v") != fields.end();
+    if (!hasU || !hasV) {
+        throw eckit::BadValue("Wind drought requires wind component fields 'u' and 'v'.", Here());
     }
+
     windSpeedCutout_ = static_cast<FIELD_TYPE_REAL>(config.getDouble("wind_speed_cutout"));
     if (windSpeedCutout_ < 0) {
         throw eckit::BadValue("The cutout wind magnitude for the wind drought event should be greater than 0", Here());
     }
 
     windDroughtSteps_.assign(coarseMapping_.size(), 0);
-    timeWindow_  = config.getUnsigned("time_window");
-    ntimeSteps_  = std::ceil(timeWindow_ * 60 / modelData.getDouble("TSTEP"));
-    description_ = "Wind drought (100m wind speed remains below " + config.getString("wind_speed_cutout") +
-                   "m/s for over " + config.getString("time_window") + "minutes)";
+    timeWindow_                   = config.getUnsigned("time_window");
+    ntimeSteps_                   = std::ceil(timeWindow_ * 60 / modelData.getParam<double>("TSTEP"));
+    const bool useHeight          = heightLevel().has_value();
+    const unsigned int modelLevel = config.getUnsigned("model_level", 1);
+    levtype_                      = useHeight ? "hl" : "ml";
+    level_                        = useHeight ? std::to_string(*heightLevel()) : std::to_string(modelLevel);
+    if (!useHeight && modelLevel > modelData.getParam<int>("NFLEVG")) {
+        throw eckit::BadValue(
+            "The specified level for the wind drought event is higher than the number of levels in the model", Here());
+    }
+    const std::string levelStr = useHeight ? level_ + "m" : "ml " + level_;
+    description_ = "Wind drought (wind speed remains below " + config.getString("wind_speed_cutout") + "m/s for over " +
+                   config.getString("time_window") + "minutes at " + levelStr + ")";
 }
 
 std::vector<ExtremeEvent::DetectionData> WindDrought::detect(plume::data::ModelData& modelData) {
     std::vector<DetectionData> ee_points;
-    auto fieldU = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getAtlasFieldShared("100u"));
-    auto fieldV = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(modelData.getAtlasFieldShared("100v"));
-    auto halo = atlas::array::make_view<int, 1>(modelData.getAtlasFieldShared("100u").functionspace().ghost());
+    const bool useHeight = levtype_ == "hl";
+
+    auto uField = useHeight ? modelData.getParam<atlas::Field>("u", level_) : modelData.getParam<atlas::Field>("u");
+    auto vField = useHeight ? modelData.getParam<atlas::Field>("v", level_) : modelData.getParam<atlas::Field>("v");
+    auto arrayU        = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(uField);
+    auto arrayV        = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(vField);
+    auto halo          = atlas::array::make_view<int, 1>(uField.functionspace().ghost());
+    const int levelIdx = useHeight ? std::stoi(level_) - 1 : 0;
+
     // 1. Compute spatial wind speed average & update count for each cell
     for (atlas::idx_t idx = 0; idx < coarseMapping_.size(); idx++) {
         if (halo(idx) > 0) {
-            continue; // Halo counters stay at 0 so they have no effect
+            continue;  // Halo counters stay at 0 so they have no effect
         }
 
-        FIELD_TYPE_REAL windMagnitude = std::sqrt(fieldU(idx, 0) * fieldU(idx, 0) + fieldV(idx, 0) * fieldV(idx, 0));
+        FIELD_TYPE_REAL valU          = arrayU(idx, levelIdx);
+        FIELD_TYPE_REAL valV          = arrayV(idx, levelIdx);
+        FIELD_TYPE_REAL windMagnitude = std::sqrt(valU * valU + valV * valV);
         if (windMagnitude < windSpeedCutout_) {
             ++windDroughtSteps_[idx];
         }
         else {
-            windDroughtSteps_[idx] = 0; // This resets the counter if the wind finally exceeds the threshold
+            windDroughtSteps_[idx] = 0;  // This resets the counter if the wind finally exceeds the threshold
         }
     }
 
     // 2. Detect the cells that have not exceeded the wind threshold during the time window
-    /** @todo Extremes DT output these fields as levtype 'hl' levelist '100', the keys will need an update for
-     *        GRIB2 compatibility. Ideally it is fetched from Plume or the field metadata instead of being hardcoded.
-     */
-    ee_points.push_back({{}, description_, "100u/100v", "sfc", "0"});
+    ee_points.push_back({{}, description_, "u/v", levtype_, level_});
     for (atlas::idx_t idx = 0; idx < coarseMapping_.size(); idx++) {
         if (ntimeSteps_ < windDroughtSteps_[idx]) {
             ee_points[0].detectedCells.insert(coarseMapping_[idx]);

--- a/src/ee_registry/wind_drought.cc
+++ b/src/ee_registry/wind_drought.cc
@@ -57,10 +57,10 @@ std::vector<ExtremeEvent::DetectionData> WindDrought::detect(plume::data::ModelD
 
     auto uField = useHeight ? modelData.getParam<atlas::Field>("u", level_) : modelData.getParam<atlas::Field>("u");
     auto vField = useHeight ? modelData.getParam<atlas::Field>("v", level_) : modelData.getParam<atlas::Field>("v");
-    auto arrayU        = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(uField);
-    auto arrayV        = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(vField);
-    auto halo          = atlas::array::make_view<int, 1>(uField.functionspace().ghost());
-    const int levelIdx = useHeight ? std::stoi(level_) - 1 : 0;
+    auto arrayU = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(uField);
+    auto arrayV = atlas::array::make_view<const FIELD_TYPE_REAL, 2>(vField);
+    auto halo   = atlas::array::make_view<int, 1>(uField.functionspace().ghost());
+    const int levelIdx = useHeight ? 0 : std::stoi(level_) - 1;
 
     // 1. Compute spatial wind speed average & update count for each cell
     for (atlas::idx_t idx = 0; idx < coarseMapping_.size(); idx++) {

--- a/src/ee_registry/wind_drought.h
+++ b/src/ee_registry/wind_drought.h
@@ -59,7 +59,7 @@ public:
     /**
      * @brief Detects wind droughts using the definition below.
      *
-     * This event checks if the 100m wind speed for each grid point remains under a given threshold for a configured // TODO1: extend to any height
+     * This event checks if the wind speed for each grid point remains under a given threshold for a configured
      * time window. If it does, the coarse cell is marked as detected.
      *
      * @param modelData The model data that contains the wind fields to run detection on.

--- a/src/ee_registry/wind_drought.h
+++ b/src/ee_registry/wind_drought.h
@@ -28,6 +28,8 @@ class WindDrought final : public ExtremeEvent {
 private:
     static const std::string type_;
     std::string description_;
+    std::string levtype_;
+    std::string level_;
 
     unsigned int timeWindow_;
     uint16_t ntimeSteps_;
@@ -57,7 +59,7 @@ public:
     /**
      * @brief Detects wind droughts using the definition below.
      *
-     * This event checks if the 100m wind speed for each grid point remains under a given threshold for a configured
+     * This event checks if the 100m wind speed for each grid point remains under a given threshold for a configured // TODO1: extend to any height
      * time window. If it does, the coarse cell is marked as detected.
      *
      * @param modelData The model data that contains the wind fields to run detection on.

--- a/src/ee_registry/wind_drought.h
+++ b/src/ee_registry/wind_drought.h
@@ -28,6 +28,8 @@ class WindDrought final : public ExtremeEvent {
 private:
     static const std::string type_;
     std::string description_;
+    std::string levtype_;
+    std::string level_;
 
     unsigned int timeWindow_;
     uint16_t ntimeSteps_;
@@ -57,7 +59,7 @@ public:
     /**
      * @brief Detects wind droughts using the definition below.
      *
-     * This event checks if the 100m wind speed for each grid point remains under a given threshold for a configured
+     * This event checks if the wind speed for each grid point remains under a given threshold for a configured
      * time window. If it does, the coarse cell is marked as detected.
      *
      * @param modelData The model data that contains the wind fields to run detection on.

--- a/src/notification.cc
+++ b/src/notification.cc
@@ -9,6 +9,7 @@
  * does it submit to any jurisdiction.
  */
 #include <sstream>
+#include <cstdlib>
 
 #include "eckit/exception/Exceptions.h"
 #include "eckit/io/EasyCURL.h"
@@ -20,7 +21,12 @@ using namespace eckit;
 namespace ExtremeEventPlugin {
 
 AvisoNotificationHandler::AvisoNotificationHandler(const std::string& base, const std::string& notify) :
-    urlBase_(base), urlNotify_(base + notify) {
+    urlBase_(base),
+    urlNotify_(base + notify),
+    devMode_([&]() {
+        const char* devEnv = std::getenv("PLUME_PLUGIN_DEV");
+        return devEnv ? std::atoi(devEnv) : 0;
+    }()) {
     setSchemaData();
 }
 
@@ -53,9 +59,17 @@ void AvisoNotificationHandler::setSchemaData() {
         for (char& c : upperKey) {
             c = std::toupper(static_cast<unsigned char>(c));
         }
-        const char* schemaValue = std::getenv(upperKey.c_str());
-        if (!schemaValue) {
-            throw BadParameter("Schema key '" + upperKey + "' could not be found in the environment", Here());
+        std::string schemaValue;
+        if (devMode_) {
+            // For convenience to avoid relying on environment variables while developing
+            schemaValue = "dev_" + key;
+        }
+        else {
+            const char* envValue = std::getenv(upperKey.c_str());
+            if (!envValue) {
+                throw BadParameter("Schema key '" + upperKey + "' could not be found in the environment", Here());
+            }
+            schemaValue = envValue;
         }
         schemaData_[key] = schemaValue;
     }
@@ -68,7 +82,7 @@ int AvisoNotificationHandler::send(const std::string payload, const std::vector<
     auto curl = EasyCURL();
     curl.headers(headers);
 
-    if (atoi(std::getenv("PLUME_PLUGIN_DEV"))) {
+    if (devMode_) {
         // For convenience to avoid sending Aviso notifications while developing
         std::cout << urlEncode(polygon) << " " << payload << std::endl;
         return 999;

--- a/src/notification.cc
+++ b/src/notification.cc
@@ -9,6 +9,7 @@
  * does it submit to any jurisdiction.
  */
 #include <sstream>
+#include <cstdlib>
 
 #include "eckit/exception/Exceptions.h"
 #include "eckit/io/EasyCURL.h"
@@ -20,7 +21,12 @@ using namespace eckit;
 namespace ExtremeEventPlugin {
 
 AvisoNotificationHandler::AvisoNotificationHandler(const std::string& base, const std::string& notify) :
-    urlBase_(base), urlNotify_(base + notify), devMode_(atoi(std::getenv("PLUME_PLUGIN_DEV"))) {
+    urlBase_(base),
+    urlNotify_(base + notify),
+    devMode_([&]() {
+        const char* devEnv = std::getenv("PLUME_PLUGIN_DEV");
+        return devEnv ? std::atoi(devEnv) : 0;
+    }()) {
     setSchemaData();
 }
 
@@ -53,13 +59,17 @@ void AvisoNotificationHandler::setSchemaData() {
         for (char& c : upperKey) {
             c = std::toupper(static_cast<unsigned char>(c));
         }
-        const char* schemaValue = std::getenv(upperKey.c_str());
+        std::string schemaValue;
         if (devMode_) {
             // For convenience to avoid relying on environment variables while developing
-            schemaValue = ("dev_" + key).c_str();
+            schemaValue = "dev_" + key;
         }
-        if (!schemaValue) {
-            throw BadParameter("Schema key '" + upperKey + "' could not be found in the environment", Here());
+        else {
+            const char* envValue = std::getenv(upperKey.c_str());
+            if (!envValue) {
+                throw BadParameter("Schema key '" + upperKey + "' could not be found in the environment", Here());
+            }
+            schemaValue = envValue;
         }
         schemaData_[key] = schemaValue;
     }

--- a/src/notification.cc
+++ b/src/notification.cc
@@ -20,7 +20,7 @@ using namespace eckit;
 namespace ExtremeEventPlugin {
 
 AvisoNotificationHandler::AvisoNotificationHandler(const std::string& base, const std::string& notify) :
-    urlBase_(base), urlNotify_(base + notify) {
+    urlBase_(base), urlNotify_(base + notify), devMode_(atoi(std::getenv("PLUME_PLUGIN_DEV"))) {
     setSchemaData();
 }
 
@@ -54,6 +54,10 @@ void AvisoNotificationHandler::setSchemaData() {
             c = std::toupper(static_cast<unsigned char>(c));
         }
         const char* schemaValue = std::getenv(upperKey.c_str());
+        if (devMode_) {
+            // For convenience to avoid relying on environment variables while developing
+            schemaValue = ("dev_" + key).c_str();
+        }
         if (!schemaValue) {
             throw BadParameter("Schema key '" + upperKey + "' could not be found in the environment", Here());
         }
@@ -68,7 +72,7 @@ int AvisoNotificationHandler::send(const std::string payload, const std::vector<
     auto curl = EasyCURL();
     curl.headers(headers);
 
-    if (atoi(std::getenv("PLUME_PLUGIN_DEV"))) {
+    if (devMode_) {
         // For convenience to avoid sending Aviso notifications while developing
         std::cout << urlEncode(polygon) << " " << payload << std::endl;
         return 999;

--- a/src/notification.h
+++ b/src/notification.h
@@ -29,6 +29,7 @@ class AvisoNotificationHandler {
 private:
     std::string urlBase_;    ///< The Aviso server url.
     std::string urlNotify_;  ///< The notification endpoint.
+    bool devMode_;           ///< If true, notifications are not being sent to the Aviso server.
 
     /**
      * @brief The Aviso MARS schema required keys.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,31 +1,41 @@
-set(EE_PLUGIN_TEST_FILES_H    
-    ../src/notification.h
-    ../src/healpix_utils.h
-    ../src/ee_plugin.h
-    ../src/ee_registry/ee_base.h
-    ../src/ee_registry/ee_registry.h
-    ../src/ee_registry/extreme_wind.h
-    ../src/ee_registry/storm.h
-    ../src/ee_registry/extreme_wave.h
-    ../src/ee_registry/wind_drought.h
-    ../src/ee_registry/ramp.h
-    ../src/plugin_types.h
+# 
+#  (C) Copyright 2023- ECMWF.
+# 
+#  This software is licensed under the terms of the Apache Licence Version 2.0
+#  which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# 
+#  In applying this licence, ECMWF does not waive the privileges and immunities
+#  granted to it by virtue of its status as an intergovernmental organisation nor
+#  does it submit to any jurisdiction.
+# 
+set(EE_PLUGIN_TEST_FILES_H
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/notification.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/healpix_utils.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ee_plugin.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ee_registry/ee_base.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ee_registry/ee_registry.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ee_registry/extreme_wind.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ee_registry/storm.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ee_registry/extreme_wave.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ee_registry/wind_drought.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ee_registry/ramp.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/plugin_types.h
 )
 
 
 # ee_plugin_registration.cc module is excluded in the compilation of the tests
 # because eckit plugin deregistration causes a segmentation fault
 # see Jira issue ECKIT-520 for more details
-set(EE_PLUGIN_TEST_FILES_CC    
-    ../src/notification.cc
-    ../src/healpix_utils.cc
-    ../src/ee_plugin.cc
-    ../src/ee_registry/ee_registry.cc
-    ../src/ee_registry/extreme_wind.cc
-    ../src/ee_registry/storm.cc
-    ../src/ee_registry/extreme_wave.cc
-    ../src/ee_registry/wind_drought.cc
-    ../src/ee_registry/ramp.cc
+set(EE_PLUGIN_TEST_FILES_CC
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/notification.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/healpix_utils.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ee_plugin.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ee_registry/ee_registry.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ee_registry/extreme_wind.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ee_registry/storm.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ee_registry/extreme_wave.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ee_registry/wind_drought.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ee_registry/ramp.cc
 )
 
 set(EE_PLUGIN_TEST_SOURCES
@@ -50,21 +60,32 @@ foreach(prec sp dp)
     endif()
 endforeach()
 
+add_subdirectory(events)
+
 foreach(prec sp dp)
     if (HAVE_EE_PLUGIN_${prec} AND HAVE_NWP_EMULATOR_TESTS)
+        set(EE_PLUGIN_RUN_TEST_SCRIPT_${prec}
+            ${CMAKE_BINARY_DIR}/bin/check_emulator_notifications_${prec}.sh
+        )
+        ecbuild_configure_file(check_emulator_notifications.sh.in
+                               ${EE_PLUGIN_RUN_TEST_SCRIPT_${prec}} @ONLY)
         ecbuild_add_test(
+            TYPE SCRIPT
             TARGET  ee_plugin_run_test_${prec}
-            COMMAND nwp_emulator_run_${prec}.x
-            ENVIRONMENT CLASS="test"
-                        TYPE="test"
-                        EXPVER="0001"
-                        DATE="00000000"
-                        TIME="0000"
-                        PLUME_PLUGIN_DEV=1
+            COMMAND ${EE_PLUGIN_RUN_TEST_SCRIPT_${prec}}
+            ENVIRONMENT PLUME_PLUGIN_DEV=1
+                        NWP_EMULATOR_RUN_BIN=$<TARGET_FILE:nwp_emulator_run_${prec}.x>
                         DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{DYLD_LIBRARY_PATH}
                         LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}
-            ARGS --config-src=${CMAKE_CURRENT_SOURCE_DIR}/data/emulator_config.yml
-                --plume-cfg=${CMAKE_CURRENT_SOURCE_DIR}/data/plume_config_${prec}.yml
+            ARGS ${CMAKE_CURRENT_SOURCE_DIR}/data/emulator_config.yml
+                ${CMAKE_CURRENT_SOURCE_DIR}/data/plume_config_${prec}.yml
+                "No wind"
+                "Extremely strong wind"
+                "Storm ("
+                "Storm conditions"
+                "Unsafe offshore wind-farm operations"
+                "Wind drought"
+                "Ramp"
         )
     endif()
 endforeach()

--- a/tests/check_emulator_notifications.sh.in
+++ b/tests/check_emulator_notifications.sh.in
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -lt 3 ]]; then
+  echo "Usage: $0 <config_src> <plume_cfg> <event_name...>" >&2
+  exit 2
+fi
+
+emulator_exe="${NWP_EMULATOR_RUN_BIN:?NWP_EMULATOR_RUN_BIN is not set}"
+config_src="$1"
+plume_cfg="$2"
+shift 2
+
+output_file="$(mktemp)"
+payload_file="$(mktemp)"
+trap 'rm -f "$output_file" "$payload_file"' EXIT
+
+if [[ ! -x "$emulator_exe" ]]; then
+  echo "Emulator executable not found or not executable: $emulator_exe" >&2
+  exit 1
+fi
+
+if ! "$emulator_exe" --config-src="$config_src" --plume-cfg="$plume_cfg" >"$output_file" 2>&1; then
+  echo "Emulator failed. Output:" >&2
+  cat "$output_file" >&2
+  exit 1
+fi
+
+awk 'match($0, /\{.*\}$/) { print substr($0, RSTART, RLENGTH) }' "$output_file" >"$payload_file"
+
+missing=0
+if ! grep -q . "$payload_file"; then
+  echo "No notification payloads captured." >&2
+  missing=1
+fi
+for event in "$@"; do
+  if ! grep -q "$event" "$payload_file"; then
+    echo "Missing event notification for: $event" >&2
+    missing=1
+  fi
+done
+
+grep -n "description" "$payload_file" || true
+
+if [[ "$missing" -ne 0 ]]; then
+  echo "Notification payloads:" >&2
+  cat "$payload_file" >&2
+  echo "Emulator output:" >&2
+  cat "$output_file" >&2
+  exit 1
+fi

--- a/tests/data/emulator_config.yml
+++ b/tests/data/emulator_config.yml
@@ -3,21 +3,6 @@ emulator:
   grid_identifier: "N80"
   vertical_levels: 5
   fields:
-    100u:
-      levtype: "sfc"
-      apply:
-        step:
-          value: 10.0
-          variation: -2.5
-    100v:
-      levtype: "sfc"
-      apply:
-        vortex_rollup:
-          time_variation: 1.1
-        step:
-          area: [71.5, -25, 34.5, 45]
-          value: 30.0
-          variation: -7.5
     2t:
       levtype: "sfc"
       apply:
@@ -30,24 +15,70 @@ emulator:
         levels:
           "1":
             random:
-              min: 1.0
-              max: 5.0
+              min: 0.0
+              max: 0.0
             step:
               area: [71.5, -25, 34.5, 45] # rectangle represented by NW and SE (lat,lon) coordinates
-              value: 0.0
-              variation: 0.12
+              value: 30.0
+              variation: 0.0
           "2":
             random:
-              min: 1.0
-              max: 5.0
+              min: 0.0
+              max: 0.0
             step:
               area: [-10, 113, -43.7, 155.3]
               value: 0.0
-              variation: 0.12
-    v: "u"
+              variation: 0.0
+          "3":
+            step:
+              area: [71.5, -25, 34.5, 45]
+              value: 40.0
+          "4":
+            step:
+              area: [71.5, -25, 34.5, 45]
+              value: 40.0
+    v:
+      apply:
+        levels:
+          "1":
+            random:
+              min: 0.0
+              max: 0.0
+            vortex_rollup:
+              time_variation: 1.1
+            step:
+              area: [71.5, -25, 34.5, 45]
+              value: 40.0
+              variation: 0.0
+          "2":
+            random:
+              min: 0.0
+              max: 0.0
+            step:
+              area: [-10, 113, -43.7, 155.3]
+              value: 0.0
+              variation: 0.0
+    z:
+      apply:
+        levels:
+          "1":
+            step:
+              value: 3000.0
+          "2":
+            step:
+              value: 2000.0
+          "3":
+            step:
+              value: 1000.0
+          "4":
+            step:
+              value: 500.0
+          "5":
+            step:
+              value: 100.0
     swh:
       levtype: "sfc"
       apply:
         step:
           area: [71.5, -25, 34.5, 45]
-          value: 4.0
+          value: 9.0

--- a/tests/data/plume_config_dp.yml
+++ b/tests/data/plume_config_dp.yml
@@ -4,41 +4,43 @@ plugins:
     parameters:
       - &extreme_wind
         - name: "u"
-          type: "atlas_field"
+          type: "ATLAS_FIELD"
         - name: "v"
-          type: "atlas_field"
-        - name: "100u"
-          type: "atlas_field"
-        - name: "100v"
-          type: "atlas_field"
+          type: "ATLAS_FIELD"
       - &100m_wind
-        - name: "100u"
-          type: "atlas_field"
-        - name: "100v"
-          type: "atlas_field"
+        - name: "u"
+          type: "ATLAS_FIELD"
+          height: 100
+        - name: "v"
+          type: "ATLAS_FIELD"
+          height: 100
       - &waves
         - name: "swh"
-          type: "atlas_field"
+          type: "ATLAS_FIELD"
       - &temperatureRamp
         - name: "2t"
-          type: "atlas_field"
+          type: "ATLAS_FIELD"
     core-config:
         aviso_url: "test"
         notify_endpoint: "/test"
         enable_notification: true
-        healpix_res: 16
+        healpix_res: 8
         events:
           - name: "extreme_wind"
             enabled: true
             required_params: *extreme_wind
             instances:
-              - lower_bound: 25.0
-                upper_bound: 0.0
-                description: "Extremely strong wind"
               - lower_bound: 0.0
                 upper_bound: 0.5
                 model_levels: [1, 2]
                 description: "No wind"
+          - name: "extreme_wind"
+            enabled: true
+            required_params: *100m_wind
+            instances:
+              - lower_bound: 25.0
+                upper_bound: 0.0
+                description: "Extremely strong wind"
           - name: "storm"
             enabled: true
             required_params: *100m_wind

--- a/tests/data/plume_config_sp.yml
+++ b/tests/data/plume_config_sp.yml
@@ -4,41 +4,43 @@ plugins:
     parameters:
       - &extreme_wind
         - name: "u"
-          type: "atlas_field"
+          type: "ATLAS_FIELD"
         - name: "v"
-          type: "atlas_field"
-        - name: "100u"
-          type: "atlas_field"
-        - name: "100v"
-          type: "atlas_field"
+          type: "ATLAS_FIELD"
       - &100m_wind
-        - name: "100u"
-          type: "atlas_field"
-        - name: "100v"
-          type: "atlas_field"
+        - name: "u"
+          type: "ATLAS_FIELD"
+          height: 100
+        - name: "v"
+          type: "ATLAS_FIELD"
+          height: 100
       - &waves
         - name: "swh"
-          type: "atlas_field"
+          type: "ATLAS_FIELD"
       - &temperatureRamp
         - name: "2t"
-          type: "atlas_field"
+          type: "ATLAS_FIELD"
     core-config:
         aviso_url: "test"
         notify_endpoint: "/test"
         enable_notification: true
-        healpix_res: 16
+        healpix_res: 8
         events:
           - name: "extreme_wind"
             enabled: true
             required_params: *extreme_wind
             instances:
-              - lower_bound: 25.0
-                upper_bound: 0.0
-                description: "Extremely strong wind"
               - lower_bound: 0.0
                 upper_bound: 0.5
                 model_levels: [1, 2]
                 description: "No wind"
+          - name: "extreme_wind"
+            enabled: true
+            required_params: *100m_wind
+            instances:
+              - lower_bound: 25.0
+                upper_bound: 0.0
+                description: "Extremely strong wind"
           - name: "storm"
             enabled: true
             required_params: *100m_wind

--- a/tests/events/CMakeLists.txt
+++ b/tests/events/CMakeLists.txt
@@ -1,0 +1,74 @@
+# 
+#  (C) Copyright 2023- ECMWF.
+# 
+#  This software is licensed under the terms of the Apache Licence Version 2.0
+#  which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# 
+#  In applying this licence, ECMWF does not waive the privileges and immunities
+#  granted to it by virtue of its status as an intergovernmental organisation nor
+#  does it submit to any jurisdiction.
+# 
+foreach(prec sp dp)
+    if (HAVE_EE_PLUGIN_${prec})
+        ecbuild_add_test (
+            TARGET ee_plugin_test_storm_${prec}
+            SOURCES
+                ${EE_PLUGIN_TEST_SOURCES}
+                test_storm.cc
+            INCLUDES
+                ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+                $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>
+            LIBS
+                eckit
+                plume_plugin
+        )
+        ecbuild_add_test (
+            TARGET ee_plugin_test_extreme_wind_${prec}
+            SOURCES
+                ${EE_PLUGIN_TEST_SOURCES}
+                test_extreme_wind.cc
+            INCLUDES
+                ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+                $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>
+            LIBS
+                eckit
+                plume_plugin
+        )
+        ecbuild_add_test (
+            TARGET ee_plugin_test_extreme_wave_${prec}
+            SOURCES
+                ${EE_PLUGIN_TEST_SOURCES}
+                test_extreme_wave.cc
+            INCLUDES
+                ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+                $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>
+            LIBS
+                eckit
+                plume_plugin
+        )
+        ecbuild_add_test (
+            TARGET ee_plugin_test_wind_drought_${prec}
+            SOURCES
+                ${EE_PLUGIN_TEST_SOURCES}
+                test_wind_drought.cc
+            INCLUDES
+                ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+                $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>
+            LIBS
+                eckit
+                plume_plugin
+        )
+        ecbuild_add_test (
+            TARGET ee_plugin_test_ramp_${prec}
+            SOURCES
+                ${EE_PLUGIN_TEST_SOURCES}
+                test_ramp.cc
+            INCLUDES
+                ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+                $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>
+            LIBS
+                eckit
+                plume_plugin
+        )
+    endif()
+endforeach()

--- a/tests/events/test_extreme_wave.cc
+++ b/tests/events/test_extreme_wave.cc
@@ -1,0 +1,123 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <array>
+#include <vector>
+
+#include "atlas/array.h"
+#include "atlas/field.h"
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/grid.h"
+#include "atlas/option.h"
+#include "eckit/config/LocalConfiguration.h"
+#include "eckit/exception/Exceptions.h"
+#include "eckit/testing/Test.h"
+#include "plume/data/ModelData.h"
+#include "plume/data/ParameterValue.h"
+
+#include "ee_registry/extreme_wave.h"
+#include "plugin_types.h"
+
+using namespace eckit::testing;
+
+namespace {
+
+struct ExtremeWaveFixture {
+    plume::data::ModelData data;
+    atlas::Grid grid;
+    atlas::functionspace::NodeColumns fs;
+    atlas::Field swh;
+    std::vector<int> coarseMapping;
+
+    ExtremeWaveFixture() :
+        grid("O1"),
+        fs(grid, atlas::option::halo(0)),
+        swh(fs.createField<FIELD_TYPE_REAL>(atlas::option::name("swh") | atlas::option::levels(1))) {
+        ASSERT(swh.shape(0) > 2);
+        coarseMapping.assign(swh.shape(0), 0);
+        coarseMapping[0] = 1;
+        coarseMapping[1] = 1;
+        coarseMapping[2] = 2;
+
+        data.provideParam("swh", &swh);
+        // data.createParam("TSTEP", 300.0);
+        // data.createParam("NSTEP", 0);
+    }
+
+    void setValues(const std::array<FIELD_TYPE_REAL, 3>& values) {
+        auto view = atlas::array::make_view<FIELD_TYPE_REAL, 2>(swh);
+        for (atlas::idx_t i = 0; i < view.shape(0); ++i) {
+            view(i, 0) = 0;
+        }
+        view(0, 0) = values[0];
+        view(1, 0) = values[1];
+        view(2, 0) = values[2];
+    }
+};
+
+eckit::LocalConfiguration extremeWaveConfig(const std::vector<double>& thresholds, int missingValue = 9999) {
+    eckit::LocalConfiguration config;
+    config.set("name", "extreme_wave");
+    config.set("missing_value", missingValue);
+
+    eckit::LocalConfiguration swhParam;
+    swhParam.set("name", "swh");
+    swhParam.set("type", "ATLAS_FIELD");
+    config.set("required_params", std::vector<eckit::LocalConfiguration>{swhParam});
+
+    std::vector<eckit::LocalConfiguration> instances;
+    for (double threshold : thresholds) {
+        eckit::LocalConfiguration instance;
+        instance.set("threshold", threshold);
+        instance.set("description", "test waves");
+        instances.push_back(instance);
+    }
+    config.set("instances", instances);
+
+    return config;
+}
+
+}  // namespace
+
+namespace test {
+
+CASE("extreme wave rejects non swh field") {
+    ExtremeWaveFixture fixture;
+    auto config         = extremeWaveConfig({2.0});
+    std::string swhPath =
+        std::string("required_params") + config.separator() + "0" + config.separator() + "name";
+    config.set(swhPath, "u");
+
+    EXPECT_THROWS_AS(ExtremeWave(config, fixture.data, fixture.coarseMapping), eckit::BadValue);
+}
+
+CASE("extreme wave detection respects thresholds and missing values") {
+    ExtremeWaveFixture fixture;
+    auto config = extremeWaveConfig({8.0, 3.5}, 9999);
+    ExtremeWave event(config, fixture.data, fixture.coarseMapping);
+
+    fixture.setValues({9999.0, 5.0, 9.0});
+    auto detected = event.detect(fixture.data);
+
+    EXPECT_EQUAL(detected.size(), 2);
+    const auto& high = detected[0].detectedCells;
+    const auto& low  = detected[1].detectedCells;
+
+    EXPECT(high.find(1) == high.end());
+    EXPECT(high.find(2) != high.end());
+    EXPECT(low.find(1) != low.end());
+    EXPECT(low.find(2) != low.end());
+}
+
+}  // namespace test
+
+int main(int argc, char** argv) {
+    return run_tests(argc, argv);
+}

--- a/tests/events/test_extreme_wind.cc
+++ b/tests/events/test_extreme_wind.cc
@@ -1,0 +1,176 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <array>
+#include <optional>
+#include <vector>
+
+#include "atlas/array.h"
+#include "atlas/field.h"
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/grid.h"
+#include "atlas/option.h"
+#include "eckit/config/LocalConfiguration.h"
+#include "eckit/exception/Exceptions.h"
+#include "eckit/testing/Test.h"
+#include "plume/data/ModelData.h"
+#include "plume/data/ParameterValue.h"
+
+#include "ee_registry/extreme_wind.h"
+#include "plugin_types.h"
+
+using namespace eckit::testing;
+
+namespace {
+
+struct ExtremeWindFixture {
+    plume::data::ModelData data;
+    atlas::Grid grid;
+    atlas::functionspace::NodeColumns fs;
+    std::optional<std::string> height;
+    atlas::Field u;
+    atlas::Field v;
+    std::vector<int> coarseMapping;
+
+    explicit ExtremeWindFixture(int nflevg = 1, std::optional<std::string> height = std::nullopt) :
+        grid("O1"),
+        fs(grid, atlas::option::halo(0)),
+        height(height),
+        u(fs.createField<FIELD_TYPE_REAL>(atlas::option::name("u") |
+                                          atlas::option::levels(height.has_value() ? 1 : nflevg))),
+        v(fs.createField<FIELD_TYPE_REAL>(atlas::option::name("v") |
+                                          atlas::option::levels(height.has_value() ? 1 : nflevg))) {
+        ASSERT(u.shape(0) > 2);
+        coarseMapping.assign(u.shape(0), 0);
+        coarseMapping[0] = 1;
+        coarseMapping[1] = 1;
+        coarseMapping[2] = 2;
+
+        if (height.has_value()) {
+            nflevg = 1;
+        }
+        std::string uStr =
+            height.has_value() ? plume::data::IParameterObserver::deriveParamName("u", "hl", *height) : "u";
+        std::string vStr =
+            height.has_value() ? plume::data::IParameterObserver::deriveParamName("v", "hl", *height) : "v";
+        data.provideParam(uStr, &u);
+        data.provideParam(vStr, &v);
+        data.createParam("NFLEVG", nflevg);
+        data.createParam("TSTEP", 300.0);
+        data.createParam("NSTEP", 0);
+    }
+
+    void setLevelValues(const std::array<FIELD_TYPE_REAL, 3>& values, int level = 0) {
+        auto setValues = [&](auto& uView, auto& vView, auto mutator) {
+            for (atlas::idx_t i = 0; i < uView.shape(0); ++i) {
+                mutator(uView, i, 0, level);
+                mutator(vView, i, 0, level);
+            }
+            mutator(uView, 0, values[0], level);
+            mutator(uView, 1, values[1], level);
+            mutator(uView, 2, values[2], level);
+        };
+
+        auto uView = atlas::array::make_view<FIELD_TYPE_REAL, 2>(u);
+        auto vView = atlas::array::make_view<FIELD_TYPE_REAL, 2>(v);
+        setValues(uView, vView,
+                  [](auto& field, atlas::idx_t i, FIELD_TYPE_REAL value, int level) { field(i, level) = value; });
+    }
+};
+
+eckit::LocalConfiguration extremeWindConfig(double lowerBound, double upperBound,
+                                            std::optional<std::string> height           = std::nullopt,
+                                            std::optional<std::vector<int>> modelLevels = std::nullopt) {
+    eckit::LocalConfiguration config;
+    config.set("name", "extreme_wind");
+
+    eckit::LocalConfiguration uParam;
+    uParam.set("name", "u");
+    uParam.set("type", "ATLAS_FIELD");
+    eckit::LocalConfiguration vParam;
+    vParam.set("name", "v");
+    vParam.set("type", "ATLAS_FIELD");
+
+    if (height.has_value()) {
+        uParam.set("height", *height);
+        vParam.set("height", *height);
+    }
+
+    std::vector<eckit::LocalConfiguration> reqParams{uParam, vParam};
+    config.set("required_params", reqParams);
+
+    eckit::LocalConfiguration instance;
+    instance.set("lower_bound", lowerBound);
+    instance.set("upper_bound", upperBound);
+    instance.set("description", "test extreme wind");
+    if (modelLevels.has_value()) {
+        instance.set("model_levels", *modelLevels);
+    }
+    config.set("instances", std::vector<eckit::LocalConfiguration>{instance});
+
+    return config;
+}
+
+}  // namespace
+
+namespace test {
+
+CASE("extreme wind rejects unsupported fields") {
+    ExtremeWindFixture fixture;
+    auto config       = extremeWindConfig(10.0, 0.0);
+    std::string uPath =
+        std::string("required_params") + config.separator() + "0" + config.separator() + "name";
+    config.set(uPath, "bad_field");
+
+    EXPECT_THROWS_AS(ExtremeWind(config, fixture.data, fixture.coarseMapping), eckit::BadValue);
+}
+
+CASE("extreme wind rejects model level above NFLEVG") {
+    ExtremeWindFixture fixture(1);
+    auto config = extremeWindConfig(20.0, 0.0, std::nullopt, std::vector<int>{2});
+    EXPECT_THROWS_AS(ExtremeWind(config, fixture.data, fixture.coarseMapping), eckit::BadValue);
+}
+
+CASE("extreme wind detection on model levels") {
+    ExtremeWindFixture fixture(2);
+    auto config = extremeWindConfig(18.0, 0.0, std::nullopt, std::vector<int>{1});
+    ExtremeWind event(config, fixture.data, fixture.coarseMapping);
+
+    fixture.setLevelValues({10.0, 20.0, 5.0}, 0);
+    auto detected = event.detect(fixture.data);
+
+    EXPECT_EQUAL(detected.size(), 1);
+    const auto& cells = detected[0].detectedCells;
+    EXPECT(cells.find(0) == cells.end());
+    EXPECT(cells.find(1) != cells.end());
+    EXPECT(cells.find(2) == cells.end());
+}
+
+CASE("extreme wind detection on height levels") {
+    std::string height = "100";
+    ExtremeWindFixture fixture(0, height);
+    auto config = extremeWindConfig(18.0, 0.0, height, std::nullopt);
+    ExtremeWind event(config, fixture.data, fixture.coarseMapping);
+
+    fixture.setLevelValues({10.0, 20.0, 5.0});
+    auto detected = event.detect(fixture.data);
+
+    EXPECT_EQUAL(detected.size(), 1);
+    const auto& cells = detected[0].detectedCells;
+    EXPECT(cells.find(0) == cells.end());
+    EXPECT(cells.find(1) != cells.end());
+    EXPECT(cells.find(2) == cells.end());
+}
+
+}  // namespace test
+
+int main(int argc, char** argv) {
+    return run_tests(argc, argv);
+}

--- a/tests/events/test_extreme_wind.cc
+++ b/tests/events/test_extreme_wind.cc
@@ -1,0 +1,180 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <array>
+#include <optional>
+#include <vector>
+
+#include "atlas/array.h"
+#include "atlas/field.h"
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/grid.h"
+#include "atlas/option.h"
+#include "eckit/config/LocalConfiguration.h"
+#include "eckit/exception/Exceptions.h"
+#include "eckit/testing/Test.h"
+#include "plume/data/ModelData.h"
+#include "plume/data/ParameterValue.h"
+
+#include "ee_registry/extreme_wind.h"
+#include "plugin_types.h"
+
+using namespace eckit::testing;
+
+namespace {
+
+struct ExtremeWindFixture {
+    plume::data::ModelData data;
+    atlas::Grid grid;
+    atlas::functionspace::NodeColumns fs;
+    std::optional<std::string> height;
+    atlas::Field u;
+    atlas::Field v;
+    std::vector<int> coarseMapping;
+
+    explicit ExtremeWindFixture(int nflevg = 1, std::optional<std::string> height = std::nullopt) :
+        grid("O1"),
+        fs(grid, atlas::option::halo(0)),
+        height(height),
+        u(fs.createField<FIELD_TYPE_REAL>(atlas::option::name("u") |
+                                          atlas::option::levels(height.has_value() ? 1 : nflevg))),
+        v(fs.createField<FIELD_TYPE_REAL>(atlas::option::name("v") |
+                                          atlas::option::levels(height.has_value() ? 1 : nflevg))) {
+        ASSERT(u.shape(0) > 2);
+        coarseMapping.assign(u.shape(0), 0);
+        coarseMapping[0] = 1;
+        coarseMapping[1] = 1;
+        coarseMapping[2] = 2;
+
+        if (height.has_value()) {
+            nflevg = 1;
+        }
+        std::string uStr =
+            height.has_value() ? plume::data::IParameterObserver::deriveParamName("u", "hl", *height) : "u";
+        std::string vStr =
+            height.has_value() ? plume::data::IParameterObserver::deriveParamName("v", "hl", *height) : "v";
+        data.provideParam(uStr, &u);
+        data.provideParam(vStr, &v);
+        data.createParam("NFLEVG", nflevg);
+        data.createParam("TSTEP", 300.0);
+        data.createParam("NSTEP", 0);
+    }
+
+    void setLevelValues(const std::array<FIELD_TYPE_REAL, 3>& uValues,
+                        const std::array<FIELD_TYPE_REAL, 3>& vValues, int level = 0) {
+        auto setValues = [&](auto& uView, auto& vView, auto mutator) {
+            for (atlas::idx_t i = 0; i < uView.shape(0); ++i) {
+                mutator(uView, i, 0, level);
+                mutator(vView, i, 0, level);
+            }
+            mutator(uView, 0, uValues[0], level);
+            mutator(uView, 1, uValues[1], level);
+            mutator(uView, 2, uValues[2], level);
+            mutator(vView, 0, vValues[0], level);
+            mutator(vView, 1, vValues[1], level);
+            mutator(vView, 2, vValues[2], level);
+        };
+
+        auto uView = atlas::array::make_view<FIELD_TYPE_REAL, 2>(u);
+        auto vView = atlas::array::make_view<FIELD_TYPE_REAL, 2>(v);
+        setValues(uView, vView,
+                  [](auto& field, atlas::idx_t i, FIELD_TYPE_REAL value, int level) { field(i, level) = value; });
+    }
+};
+
+eckit::LocalConfiguration extremeWindConfig(double lowerBound, double upperBound,
+                                            std::optional<std::string> height           = std::nullopt,
+                                            std::optional<std::vector<int>> modelLevels = std::nullopt) {
+    eckit::LocalConfiguration config;
+    config.set("name", "extreme_wind");
+
+    eckit::LocalConfiguration uParam;
+    uParam.set("name", "u");
+    uParam.set("type", "ATLAS_FIELD");
+    eckit::LocalConfiguration vParam;
+    vParam.set("name", "v");
+    vParam.set("type", "ATLAS_FIELD");
+
+    if (height.has_value()) {
+        uParam.set("height", *height);
+        vParam.set("height", *height);
+    }
+
+    std::vector<eckit::LocalConfiguration> reqParams{uParam, vParam};
+    config.set("required_params", reqParams);
+
+    eckit::LocalConfiguration instance;
+    instance.set("lower_bound", lowerBound);
+    instance.set("upper_bound", upperBound);
+    instance.set("description", "test extreme wind");
+    if (modelLevels.has_value()) {
+        instance.set("model_levels", *modelLevels);
+    }
+    config.set("instances", std::vector<eckit::LocalConfiguration>{instance});
+
+    return config;
+}
+
+}  // namespace
+
+namespace test {
+
+CASE("extreme wind rejects unsupported fields") {
+    ExtremeWindFixture fixture;
+    auto config       = extremeWindConfig(10.0, 0.0);
+    std::string uPath =
+        std::string("required_params") + config.separator() + "0" + config.separator() + "name";
+    config.set(uPath, "bad_field");
+
+    EXPECT_THROWS_AS(ExtremeWind(config, fixture.data, fixture.coarseMapping), eckit::BadValue);
+}
+
+CASE("extreme wind rejects model level above NFLEVG") {
+    ExtremeWindFixture fixture(1);
+    auto config = extremeWindConfig(20.0, 0.0, std::nullopt, std::vector<int>{2});
+    EXPECT_THROWS_AS(ExtremeWind(config, fixture.data, fixture.coarseMapping), eckit::BadValue);
+}
+
+CASE("extreme wind detection on model levels") {
+    ExtremeWindFixture fixture(2);
+    auto config = extremeWindConfig(18.0, 0.0, std::nullopt, std::vector<int>{1});
+    ExtremeWind event(config, fixture.data, fixture.coarseMapping);
+
+    fixture.setLevelValues({10.0, 20.0, 5.0}, {5.0, 10.0, 2.5}, 0);
+    auto detected = event.detect(fixture.data);
+
+    EXPECT_EQUAL(detected.size(), 1);
+    const auto& cells = detected[0].detectedCells;
+    EXPECT(cells.find(0) == cells.end());
+    EXPECT(cells.find(1) != cells.end());
+    EXPECT(cells.find(2) == cells.end());
+}
+
+CASE("extreme wind detection on height levels") {
+    std::string height = "100";
+    ExtremeWindFixture fixture(0, height);
+    auto config = extremeWindConfig(18.0, 0.0, height, std::nullopt);
+    ExtremeWind event(config, fixture.data, fixture.coarseMapping);
+
+    fixture.setLevelValues({10.0, 20.0, 5.0}, {5.0, 10.0, 2.5});
+    auto detected = event.detect(fixture.data);
+
+    EXPECT_EQUAL(detected.size(), 1);
+    const auto& cells = detected[0].detectedCells;
+    EXPECT(cells.find(0) == cells.end());
+    EXPECT(cells.find(1) != cells.end());
+    EXPECT(cells.find(2) == cells.end());
+}
+
+}  // namespace test
+
+int main(int argc, char** argv) {
+    return run_tests(argc, argv);
+}

--- a/tests/events/test_extreme_wind.cc
+++ b/tests/events/test_extreme_wind.cc
@@ -67,15 +67,19 @@ struct ExtremeWindFixture {
         data.createParam("NSTEP", 0);
     }
 
-    void setLevelValues(const std::array<FIELD_TYPE_REAL, 3>& values, int level = 0) {
+    void setLevelValues(const std::array<FIELD_TYPE_REAL, 3>& uValues,
+                        const std::array<FIELD_TYPE_REAL, 3>& vValues, int level = 0) {
         auto setValues = [&](auto& uView, auto& vView, auto mutator) {
             for (atlas::idx_t i = 0; i < uView.shape(0); ++i) {
                 mutator(uView, i, 0, level);
                 mutator(vView, i, 0, level);
             }
-            mutator(uView, 0, values[0], level);
-            mutator(uView, 1, values[1], level);
-            mutator(uView, 2, values[2], level);
+            mutator(uView, 0, uValues[0], level);
+            mutator(uView, 1, uValues[1], level);
+            mutator(uView, 2, uValues[2], level);
+            mutator(vView, 0, vValues[0], level);
+            mutator(vView, 1, vValues[1], level);
+            mutator(vView, 2, vValues[2], level);
         };
 
         auto uView = atlas::array::make_view<FIELD_TYPE_REAL, 2>(u);
@@ -143,7 +147,7 @@ CASE("extreme wind detection on model levels") {
     auto config = extremeWindConfig(18.0, 0.0, std::nullopt, std::vector<int>{1});
     ExtremeWind event(config, fixture.data, fixture.coarseMapping);
 
-    fixture.setLevelValues({10.0, 20.0, 5.0}, 0);
+    fixture.setLevelValues({10.0, 20.0, 5.0}, {5.0, 10.0, 2.5}, 0);
     auto detected = event.detect(fixture.data);
 
     EXPECT_EQUAL(detected.size(), 1);
@@ -159,7 +163,7 @@ CASE("extreme wind detection on height levels") {
     auto config = extremeWindConfig(18.0, 0.0, height, std::nullopt);
     ExtremeWind event(config, fixture.data, fixture.coarseMapping);
 
-    fixture.setLevelValues({10.0, 20.0, 5.0});
+    fixture.setLevelValues({10.0, 20.0, 5.0}, {5.0, 10.0, 2.5});
     auto detected = event.detect(fixture.data);
 
     EXPECT_EQUAL(detected.size(), 1);

--- a/tests/events/test_ramp.cc
+++ b/tests/events/test_ramp.cc
@@ -1,0 +1,133 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <array>
+#include <optional>
+#include <vector>
+
+#include "atlas/array.h"
+#include "atlas/field.h"
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/grid.h"
+#include "atlas/option.h"
+#include "eckit/config/LocalConfiguration.h"
+#include "eckit/exception/Exceptions.h"
+#include "eckit/testing/Test.h"
+#include "plume/data/ModelData.h"
+#include "plume/data/ParameterValue.h"
+
+#include "ee_registry/ramp.h"
+#include "plugin_types.h"
+
+using namespace eckit::testing;
+
+namespace {
+
+struct RampFixture {
+    plume::data::ModelData data;
+    atlas::Grid grid;
+    atlas::functionspace::NodeColumns fs;
+    atlas::Field field;
+    std::vector<int> coarseMapping;
+
+    RampFixture() :
+        grid("O1"),
+        fs(grid, atlas::option::halo(0)),
+        field(fs.createField<FIELD_TYPE_REAL>(atlas::option::name("2t") | atlas::option::levels(1))) {
+        ASSERT(field.shape(0) > 2);
+        coarseMapping.assign(field.shape(0), 0);
+        coarseMapping[0] = 1;
+        coarseMapping[1] = 1;
+        coarseMapping[2] = 2;
+
+        data.provideParam("2t", &field);
+        data.createParam("TSTEP", 300.0);
+        data.createParam("NSTEP", 0);
+    }
+
+    void setValues(const std::array<FIELD_TYPE_REAL, 3>& values) {
+        auto view = atlas::array::make_view<FIELD_TYPE_REAL, 2>(field);
+        for (atlas::idx_t i = 0; i < view.shape(0); ++i) {
+            view(i, 0) = 0;
+        }
+        view(0, 0) = values[0];
+        view(1, 0) = values[1];
+        view(2, 0) = values[2];
+    }
+};
+
+eckit::LocalConfiguration rampConfig(double rampUp, std::optional<double> rampDown, size_t timeWindow) {
+    eckit::LocalConfiguration config;
+    config.set("name", "ramp");
+    config.set("time_window", timeWindow);
+    config.set("ramp_up_value", rampUp);
+    if (rampDown.has_value()) {
+        config.set("ramp_down_value", *rampDown);
+    }
+
+    eckit::LocalConfiguration param;
+    param.set("name", "2t");
+    param.set("type", "ATLAS_FIELD");
+    config.set("required_params", std::vector<eckit::LocalConfiguration>{param});
+
+    return config;
+}
+
+}  // namespace
+
+namespace test {
+
+CASE("ramp setup rejects missing thresholds") {
+    RampFixture fixture;
+    eckit::LocalConfiguration config;
+    config.set("name", "ramp");
+    config.set("time_window", 10);
+    eckit::LocalConfiguration param;
+    param.set("name", "2t");
+    param.set("type", "ATLAS_FIELD");
+    config.set("required_params", std::vector<eckit::LocalConfiguration>{param});
+
+    EXPECT_THROWS_AS(RampEvent(config, fixture.data, fixture.coarseMapping), eckit::BadValue);
+}
+
+CASE("ramp setup rejects negative thresholds") {
+    RampFixture fixture;
+    auto config = rampConfig(-1.0, std::nullopt, 10);
+    EXPECT_THROWS_AS(RampEvent(config, fixture.data, fixture.coarseMapping), eckit::BadValue);
+}
+
+CASE("ramp detection for up and down") {
+    RampFixture fixture;
+    auto config = rampConfig(10.0, 8.0, 10);
+    RampEvent event(config, fixture.data, fixture.coarseMapping);
+
+    fixture.setValues({10.0, 10.0, 10.0});
+    fixture.data.updateParam("NSTEP", 1);
+    auto first = event.detect(fixture.data);
+    EXPECT(first.empty());
+
+    fixture.setValues({25.0, 5.0, 0.0});
+    fixture.data.updateParam("NSTEP", 2);
+    auto second = event.detect(fixture.data);
+
+    EXPECT_EQUAL(second.size(), 2);
+    const auto& rampUp   = second[0].detectedCells;
+    const auto& rampDown = second[1].detectedCells;
+    EXPECT(rampUp.find(1) != rampUp.end());
+    EXPECT(rampUp.find(2) == rampUp.end());
+    EXPECT(rampDown.find(1) == rampDown.end());
+    EXPECT(rampDown.find(2) != rampDown.end());
+}
+
+}  // namespace test
+
+int main(int argc, char** argv) {
+    return run_tests(argc, argv);
+}

--- a/tests/events/test_storm.cc
+++ b/tests/events/test_storm.cc
@@ -1,0 +1,199 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <array>
+#include <optional>
+#include <vector>
+
+#include "atlas/array.h"
+#include "atlas/field.h"
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/grid.h"
+#include "atlas/option.h"
+#include "eckit/config/LocalConfiguration.h"
+#include "eckit/exception/Exceptions.h"
+#include "eckit/testing/Test.h"
+#include "plume/data/ModelData.h"
+#include "plume/data/ParameterValue.h"
+
+#include "ee_registry/storm.h"
+#include "plugin_types.h"
+
+using namespace eckit::testing;
+
+namespace {
+
+/**
+ * @brief A test fixture for the Storm event tests.
+ */
+struct StormFixture {
+    plume::data::ModelData data;
+    atlas::Grid grid;
+    atlas::functionspace::NodeColumns fs;
+    std::optional<std::string> height;
+    atlas::Field u;
+    atlas::Field v;
+    std::vector<int> coarseMapping;
+
+    /**
+     * @brief Constructs the fixture with a grid and fields of the specified number of levels and time step.
+     */
+    explicit StormFixture(int nflevg = 1, std::optional<std::string> height = std::nullopt, double tstep = 300.0) :
+        grid("O1"),
+        fs(grid, atlas::option::halo(0)),
+        height(height),
+        u(fs.createField<FIELD_TYPE_REAL>(atlas::option::name("u") |
+                                          atlas::option::levels(height.has_value() ? 1 : nflevg))),
+        v(fs.createField<FIELD_TYPE_REAL>(atlas::option::name("v") |
+                                          atlas::option::levels(height.has_value() ? 1 : nflevg))) {
+        ASSERT(u.shape(0) > 2);
+        coarseMapping.assign(u.shape(0), 0);
+        coarseMapping[0] = 1;
+        coarseMapping[1] = 1;
+        coarseMapping[2] = 2;
+
+        if (height.has_value()) {
+            nflevg = 1;
+        }
+        std::string uStr =
+            height.has_value() ? plume::data::IParameterObserver::deriveParamName("u", "hl", *height) : "u";
+        std::string vStr =
+            height.has_value() ? plume::data::IParameterObserver::deriveParamName("v", "hl", *height) : "v";
+        data.provideParam(uStr, &u);
+        data.provideParam(vStr, &v);
+        data.createParam("NFLEVG", nflevg);
+        data.createParam("TSTEP", tstep);
+        data.createParam("NSTEP", 0);
+    }
+
+    /**
+     * @brief Sets the first three values of u and v to the provided values and rest to zero at a given level.
+     */
+    void setLevelValues(const std::array<FIELD_TYPE_REAL, 3>& values, int level = 0) {
+        auto setValues = [&](auto& uView, auto& vView, auto mutator) {
+            for (atlas::idx_t i = 0; i < uView.shape(0); ++i) {
+                mutator(uView, i, 0, level);
+                mutator(vView, i, 0, level);
+            }
+            mutator(uView, 0, values[0], level);
+            mutator(uView, 1, values[1], level);
+            mutator(uView, 2, values[2], level);
+        };
+
+        auto uView = atlas::array::make_view<FIELD_TYPE_REAL, 2>(u);
+        auto vView = atlas::array::make_view<FIELD_TYPE_REAL, 2>(v);
+        setValues(uView, vView,
+                  [](auto& field, atlas::idx_t i, FIELD_TYPE_REAL value, int level) { field(i, level) = value; });
+    }
+};
+
+/**
+ * @brief Helper function to create a storm event configuration with the specified parameters.
+ */
+eckit::LocalConfiguration stormConfig(double cutout, size_t timeWindow,
+                                      std::optional<std::string> height = std::nullopt, size_t modelLevel = 1) {
+    eckit::LocalConfiguration config;
+    config.set("name", "storm");
+    config.set("wind_speed_cutout", cutout);
+    config.set("time_window", timeWindow);
+
+    eckit::LocalConfiguration uParam;
+    uParam.set("name", "u");
+    uParam.set("type", "ATLAS_FIELD");
+    eckit::LocalConfiguration vParam;
+    vParam.set("name", "v");
+    vParam.set("type", "ATLAS_FIELD");
+
+    if (height.has_value()) {
+        uParam.set("height", *height);
+        vParam.set("height", *height);
+    }
+    else {
+        config.set("model_level", modelLevel);
+    }
+
+    std::vector<eckit::LocalConfiguration> reqParams{uParam, vParam};
+    config.set("required_params", reqParams);
+    return config;
+}
+
+}  // namespace
+
+namespace test {
+
+CASE("storm setup rejects missing wind fields") {
+    StormFixture fixture;
+    auto config       = stormConfig(20.0, 10, std::nullopt, 1);
+    std::string vPath = std::string("required_params") + config.separator() + "1" + config.separator() + "name";
+    config.set(vPath, "not_v");
+    EXPECT_THROWS_AS(Storm(config, fixture.data, fixture.coarseMapping), eckit::BadValue);
+}
+
+CASE("storm setup rejects negative cutout") {
+    StormFixture fixture;
+    auto config = stormConfig(-1.0, 10, std::nullopt, 1);
+    EXPECT_THROWS_AS(Storm(config, fixture.data, fixture.coarseMapping), eckit::BadValue);
+}
+
+CASE("storm setup rejects model level above NFLEVG") {
+    StormFixture fixture;
+    auto config = stormConfig(20.0, 10, std::nullopt, 2);
+    EXPECT_THROWS_AS(Storm(config, fixture.data, fixture.coarseMapping), eckit::BadValue);
+}
+
+CASE("storm detection on model levels") {
+    StormFixture fixture;
+    size_t modelLevel = 1;
+    auto config       = stormConfig(18.0, 10, std::nullopt, modelLevel);
+    Storm storm(config, fixture.data, fixture.coarseMapping);
+
+    fixture.setLevelValues({10.0, 20.0, 5.0}, modelLevel - 1);
+    fixture.data.updateParam("NSTEP", 1);
+    auto first = storm.detect(fixture.data);
+    EXPECT(first.empty());
+
+    fixture.setLevelValues({30.0, 10.0, 25.0}, modelLevel - 1);
+    fixture.data.updateParam("NSTEP", 2);
+    auto second = storm.detect(fixture.data);
+
+    EXPECT_EQUAL(second.size(), 1);
+    const auto& detected = second[0].detectedCells;
+    EXPECT(detected.find(0) == detected.end());
+    EXPECT(detected.find(1) != detected.end());
+    EXPECT(detected.find(2) == detected.end());
+}
+
+CASE("storm detection on height levels") {
+    std::string height = "10";
+    StormFixture fixture(0, height);
+    auto config = stormConfig(18.0, 10, height);
+    Storm storm(config, fixture.data, fixture.coarseMapping);
+
+    fixture.setLevelValues({10.0, 20.0, 5.0});
+    fixture.data.updateParam("NSTEP", 1);
+    auto first = storm.detect(fixture.data);
+    EXPECT(first.empty());
+
+    fixture.setLevelValues({30.0, 10.0, 25.0});
+    fixture.data.updateParam("NSTEP", 2);
+    auto second = storm.detect(fixture.data);
+
+    EXPECT_EQUAL(second.size(), 1);
+    const auto& detected = second[0].detectedCells;
+    EXPECT(detected.find(0) == detected.end());
+    EXPECT(detected.find(1) != detected.end());
+    EXPECT(detected.find(2) == detected.end());
+}
+
+}  // namespace test
+
+int main(int argc, char** argv) {
+    return run_tests(argc, argv);
+}

--- a/tests/events/test_storm.cc
+++ b/tests/events/test_storm.cc
@@ -76,15 +76,19 @@ struct StormFixture {
     /**
      * @brief Sets the first three values of u and v to the provided values and rest to zero at a given level.
      */
-    void setLevelValues(const std::array<FIELD_TYPE_REAL, 3>& values, int level = 0) {
+    void setLevelValues(const std::array<FIELD_TYPE_REAL, 3>& uValues,
+                        const std::array<FIELD_TYPE_REAL, 3>& vValues, int level = 0) {
         auto setValues = [&](auto& uView, auto& vView, auto mutator) {
             for (atlas::idx_t i = 0; i < uView.shape(0); ++i) {
                 mutator(uView, i, 0, level);
                 mutator(vView, i, 0, level);
             }
-            mutator(uView, 0, values[0], level);
-            mutator(uView, 1, values[1], level);
-            mutator(uView, 2, values[2], level);
+            mutator(uView, 0, uValues[0], level);
+            mutator(uView, 1, uValues[1], level);
+            mutator(uView, 2, uValues[2], level);
+            mutator(vView, 0, vValues[0], level);
+            mutator(vView, 1, vValues[1], level);
+            mutator(vView, 2, vValues[2], level);
         };
 
         auto uView = atlas::array::make_view<FIELD_TYPE_REAL, 2>(u);
@@ -154,12 +158,12 @@ CASE("storm detection on model levels") {
     auto config       = stormConfig(18.0, 10, std::nullopt, modelLevel);
     Storm storm(config, fixture.data, fixture.coarseMapping);
 
-    fixture.setLevelValues({10.0, 20.0, 5.0}, modelLevel - 1);
+    fixture.setLevelValues({10.0, 20.0, 5.0}, {5.0, 10.0, 2.5}, modelLevel - 1);
     fixture.data.updateParam("NSTEP", 1);
     auto first = storm.detect(fixture.data);
     EXPECT(first.empty());
 
-    fixture.setLevelValues({30.0, 10.0, 25.0}, modelLevel - 1);
+    fixture.setLevelValues({30.0, 10.0, 25.0}, {15.0, 5.0, 12.5}, modelLevel - 1);
     fixture.data.updateParam("NSTEP", 2);
     auto second = storm.detect(fixture.data);
 
@@ -176,12 +180,12 @@ CASE("storm detection on height levels") {
     auto config = stormConfig(18.0, 10, height);
     Storm storm(config, fixture.data, fixture.coarseMapping);
 
-    fixture.setLevelValues({10.0, 20.0, 5.0});
+    fixture.setLevelValues({10.0, 20.0, 5.0}, {5.0, 10.0, 2.5});
     fixture.data.updateParam("NSTEP", 1);
     auto first = storm.detect(fixture.data);
     EXPECT(first.empty());
 
-    fixture.setLevelValues({30.0, 10.0, 25.0});
+    fixture.setLevelValues({30.0, 10.0, 25.0}, {15.0, 5.0, 12.5});
     fixture.data.updateParam("NSTEP", 2);
     auto second = storm.detect(fixture.data);
 

--- a/tests/events/test_storm.cc
+++ b/tests/events/test_storm.cc
@@ -1,0 +1,203 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <array>
+#include <optional>
+#include <vector>
+
+#include "atlas/array.h"
+#include "atlas/field.h"
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/grid.h"
+#include "atlas/option.h"
+#include "eckit/config/LocalConfiguration.h"
+#include "eckit/exception/Exceptions.h"
+#include "eckit/testing/Test.h"
+#include "plume/data/ModelData.h"
+#include "plume/data/ParameterValue.h"
+
+#include "ee_registry/storm.h"
+#include "plugin_types.h"
+
+using namespace eckit::testing;
+
+namespace {
+
+/**
+ * @brief A test fixture for the Storm event tests.
+ */
+struct StormFixture {
+    plume::data::ModelData data;
+    atlas::Grid grid;
+    atlas::functionspace::NodeColumns fs;
+    std::optional<std::string> height;
+    atlas::Field u;
+    atlas::Field v;
+    std::vector<int> coarseMapping;
+
+    /**
+     * @brief Constructs the fixture with a grid and fields of the specified number of levels and time step.
+     */
+    explicit StormFixture(int nflevg = 1, std::optional<std::string> height = std::nullopt, double tstep = 300.0) :
+        grid("O1"),
+        fs(grid, atlas::option::halo(0)),
+        height(height),
+        u(fs.createField<FIELD_TYPE_REAL>(atlas::option::name("u") |
+                                          atlas::option::levels(height.has_value() ? 1 : nflevg))),
+        v(fs.createField<FIELD_TYPE_REAL>(atlas::option::name("v") |
+                                          atlas::option::levels(height.has_value() ? 1 : nflevg))) {
+        ASSERT(u.shape(0) > 2);
+        coarseMapping.assign(u.shape(0), 0);
+        coarseMapping[0] = 1;
+        coarseMapping[1] = 1;
+        coarseMapping[2] = 2;
+
+        if (height.has_value()) {
+            nflevg = 1;
+        }
+        std::string uStr =
+            height.has_value() ? plume::data::IParameterObserver::deriveParamName("u", "hl", *height) : "u";
+        std::string vStr =
+            height.has_value() ? plume::data::IParameterObserver::deriveParamName("v", "hl", *height) : "v";
+        data.provideParam(uStr, &u);
+        data.provideParam(vStr, &v);
+        data.createParam("NFLEVG", nflevg);
+        data.createParam("TSTEP", tstep);
+        data.createParam("NSTEP", 0);
+    }
+
+    /**
+     * @brief Sets the first three values of u and v to the provided values and rest to zero at a given level.
+     */
+    void setLevelValues(const std::array<FIELD_TYPE_REAL, 3>& uValues,
+                        const std::array<FIELD_TYPE_REAL, 3>& vValues, int level = 0) {
+        auto setValues = [&](auto& uView, auto& vView, auto mutator) {
+            for (atlas::idx_t i = 0; i < uView.shape(0); ++i) {
+                mutator(uView, i, 0, level);
+                mutator(vView, i, 0, level);
+            }
+            mutator(uView, 0, uValues[0], level);
+            mutator(uView, 1, uValues[1], level);
+            mutator(uView, 2, uValues[2], level);
+            mutator(vView, 0, vValues[0], level);
+            mutator(vView, 1, vValues[1], level);
+            mutator(vView, 2, vValues[2], level);
+        };
+
+        auto uView = atlas::array::make_view<FIELD_TYPE_REAL, 2>(u);
+        auto vView = atlas::array::make_view<FIELD_TYPE_REAL, 2>(v);
+        setValues(uView, vView,
+                  [](auto& field, atlas::idx_t i, FIELD_TYPE_REAL value, int level) { field(i, level) = value; });
+    }
+};
+
+/**
+ * @brief Helper function to create a storm event configuration with the specified parameters.
+ */
+eckit::LocalConfiguration stormConfig(double cutout, size_t timeWindow,
+                                      std::optional<std::string> height = std::nullopt, size_t modelLevel = 1) {
+    eckit::LocalConfiguration config;
+    config.set("name", "storm");
+    config.set("wind_speed_cutout", cutout);
+    config.set("time_window", timeWindow);
+
+    eckit::LocalConfiguration uParam;
+    uParam.set("name", "u");
+    uParam.set("type", "ATLAS_FIELD");
+    eckit::LocalConfiguration vParam;
+    vParam.set("name", "v");
+    vParam.set("type", "ATLAS_FIELD");
+
+    if (height.has_value()) {
+        uParam.set("height", *height);
+        vParam.set("height", *height);
+    }
+    else {
+        config.set("model_level", modelLevel);
+    }
+
+    std::vector<eckit::LocalConfiguration> reqParams{uParam, vParam};
+    config.set("required_params", reqParams);
+    return config;
+}
+
+}  // namespace
+
+namespace test {
+
+CASE("storm setup rejects missing wind fields") {
+    StormFixture fixture;
+    auto config       = stormConfig(20.0, 10, std::nullopt, 1);
+    std::string vPath = std::string("required_params") + config.separator() + "1" + config.separator() + "name";
+    config.set(vPath, "not_v");
+    EXPECT_THROWS_AS(Storm(config, fixture.data, fixture.coarseMapping), eckit::BadValue);
+}
+
+CASE("storm setup rejects negative cutout") {
+    StormFixture fixture;
+    auto config = stormConfig(-1.0, 10, std::nullopt, 1);
+    EXPECT_THROWS_AS(Storm(config, fixture.data, fixture.coarseMapping), eckit::BadValue);
+}
+
+CASE("storm setup rejects model level above NFLEVG") {
+    StormFixture fixture;
+    auto config = stormConfig(20.0, 10, std::nullopt, 2);
+    EXPECT_THROWS_AS(Storm(config, fixture.data, fixture.coarseMapping), eckit::BadValue);
+}
+
+CASE("storm detection on model levels") {
+    StormFixture fixture;
+    size_t modelLevel = 1;
+    auto config       = stormConfig(18.0, 10, std::nullopt, modelLevel);
+    Storm storm(config, fixture.data, fixture.coarseMapping);
+
+    fixture.setLevelValues({10.0, 20.0, 5.0}, {5.0, 10.0, 2.5}, modelLevel - 1);
+    fixture.data.updateParam("NSTEP", 1);
+    auto first = storm.detect(fixture.data);
+    EXPECT(first.empty());
+
+    fixture.setLevelValues({30.0, 10.0, 25.0}, {15.0, 5.0, 12.5}, modelLevel - 1);
+    fixture.data.updateParam("NSTEP", 2);
+    auto second = storm.detect(fixture.data);
+
+    EXPECT_EQUAL(second.size(), 1);
+    const auto& detected = second[0].detectedCells;
+    EXPECT(detected.find(0) == detected.end());
+    EXPECT(detected.find(1) != detected.end());
+    EXPECT(detected.find(2) == detected.end());
+}
+
+CASE("storm detection on height levels") {
+    std::string height = "10";
+    StormFixture fixture(0, height);
+    auto config = stormConfig(18.0, 10, height);
+    Storm storm(config, fixture.data, fixture.coarseMapping);
+
+    fixture.setLevelValues({10.0, 20.0, 5.0}, {5.0, 10.0, 2.5});
+    fixture.data.updateParam("NSTEP", 1);
+    auto first = storm.detect(fixture.data);
+    EXPECT(first.empty());
+
+    fixture.setLevelValues({30.0, 10.0, 25.0}, {15.0, 5.0, 12.5});
+    fixture.data.updateParam("NSTEP", 2);
+    auto second = storm.detect(fixture.data);
+
+    EXPECT_EQUAL(second.size(), 1);
+    const auto& detected = second[0].detectedCells;
+    EXPECT(detected.find(0) == detected.end());
+    EXPECT(detected.find(1) != detected.end());
+    EXPECT(detected.find(2) == detected.end());
+}
+
+}  // namespace test
+
+int main(int argc, char** argv) {
+    return run_tests(argc, argv);
+}

--- a/tests/events/test_wind_drought.cc
+++ b/tests/events/test_wind_drought.cc
@@ -1,0 +1,178 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <array>
+#include <optional>
+#include <vector>
+
+#include "atlas/array.h"
+#include "atlas/field.h"
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/grid.h"
+#include "atlas/option.h"
+#include "eckit/config/LocalConfiguration.h"
+#include "eckit/exception/Exceptions.h"
+#include "eckit/testing/Test.h"
+#include "plume/data/ModelData.h"
+#include "plume/data/ParameterValue.h"
+
+#include "ee_registry/wind_drought.h"
+#include "plugin_types.h"
+
+using namespace eckit::testing;
+
+namespace {
+
+struct WindDroughtFixture {
+    plume::data::ModelData data;
+    atlas::Grid grid;
+    atlas::functionspace::NodeColumns fs;
+    std::optional<std::string> height;
+    atlas::Field u;
+    atlas::Field v;
+    std::vector<int> coarseMapping;
+
+    explicit WindDroughtFixture(int nflevg = 1, std::optional<std::string> height = std::nullopt,
+                                double tstep = 300.0) :
+        grid("O1"),
+        fs(grid, atlas::option::halo(0)),
+        height(height),
+        u(fs.createField<FIELD_TYPE_REAL>(atlas::option::name("u") |
+                                          atlas::option::levels(height.has_value() ? 1 : nflevg))),
+        v(fs.createField<FIELD_TYPE_REAL>(atlas::option::name("v") |
+                                          atlas::option::levels(height.has_value() ? 1 : nflevg))) {
+        ASSERT(u.shape(0) > 2);
+        coarseMapping.assign(u.shape(0), 0);
+        coarseMapping[0] = 1;
+        coarseMapping[1] = 1;
+        coarseMapping[2] = 2;
+
+        if (height.has_value()) {
+            nflevg = 1;
+        }
+        std::string uStr =
+            height.has_value() ? plume::data::IParameterObserver::deriveParamName("u", "hl", *height) : "u";
+        std::string vStr =
+            height.has_value() ? plume::data::IParameterObserver::deriveParamName("v", "hl", *height) : "v";
+        data.provideParam(uStr, &u);
+        data.provideParam(vStr, &v);
+        data.createParam("NFLEVG", nflevg);
+        data.createParam("TSTEP", tstep);
+        data.createParam("NSTEP", 0);
+    }
+
+    void setValues(const std::array<FIELD_TYPE_REAL, 3>& uValues,
+                   const std::array<FIELD_TYPE_REAL, 3>& vValues, int level = 0) {
+        auto setField = [&](auto& uView, auto& vView, auto mutator) {
+            for (atlas::idx_t i = 0; i < uView.shape(0); ++i) {
+                mutator(uView, i, 0, level);
+                mutator(vView, i, 0, level);
+            }
+            mutator(uView, 0, uValues[0], level);
+            mutator(uView, 1, uValues[1], level);
+            mutator(uView, 2, uValues[2], level);
+            mutator(vView, 0, vValues[0], level);
+            mutator(vView, 1, vValues[1], level);
+            mutator(vView, 2, vValues[2], level);
+        };
+
+        auto uView = atlas::array::make_view<FIELD_TYPE_REAL, 2>(u);
+        auto vView = atlas::array::make_view<FIELD_TYPE_REAL, 2>(v);
+        setField(uView, vView,
+                 [](auto& field, atlas::idx_t i, FIELD_TYPE_REAL value, int level) { field(i, level) = value; });
+    }
+};
+
+eckit::LocalConfiguration windDroughtConfig(double cutout, size_t timeWindow,
+                                            std::optional<std::string> height = std::nullopt, size_t modelLevel = 1) {
+    eckit::LocalConfiguration config;
+    config.set("name", "wind_drought");
+    config.set("wind_speed_cutout", cutout);
+    config.set("time_window", timeWindow);
+
+    eckit::LocalConfiguration uParam;
+    uParam.set("name", "u");
+    uParam.set("type", "ATLAS_FIELD");
+    eckit::LocalConfiguration vParam;
+    vParam.set("name", "v");
+    vParam.set("type", "ATLAS_FIELD");
+
+    if (height.has_value()) {
+        uParam.set("height", *height);
+        vParam.set("height", *height);
+    }
+    else {
+        config.set("model_level", modelLevel);
+    }
+
+    std::vector<eckit::LocalConfiguration> reqParams{uParam, vParam};
+    config.set("required_params", reqParams);
+    return config;
+}
+
+}  // namespace
+
+namespace test {
+
+CASE("wind drought setup rejects negative cutout") {
+    WindDroughtFixture fixture(1, std::string("1"));
+    auto config = windDroughtConfig(-1.0, 10, std::string("1"));
+    EXPECT_THROWS_AS(WindDrought(config, fixture.data, fixture.coarseMapping), eckit::BadValue);
+}
+
+CASE("wind drought detection on height levels") {
+    std::string height = "1";
+    WindDroughtFixture fixture(1, height);
+    auto config = windDroughtConfig(2.0, 10, height);
+    WindDrought event(config, fixture.data, fixture.coarseMapping);
+
+    fixture.setValues({1.0, 1.0, 3.0}, {0.5, 0.5, 1.5});
+    auto first = event.detect(fixture.data);
+    EXPECT_EQUAL(first.size(), 1);
+    EXPECT(first[0].detectedCells.empty());
+
+    fixture.setValues({1.0, 1.0, 3.0}, {0.5, 0.5, 1.5});
+    auto second = event.detect(fixture.data);
+    EXPECT(second[0].detectedCells.empty());
+
+    fixture.setValues({1.0, 1.0, 3.0}, {0.5, 0.5, 1.5});
+    auto third        = event.detect(fixture.data);
+    const auto& cells = third[0].detectedCells;
+    EXPECT(cells.find(1) != cells.end());
+    EXPECT(cells.find(2) == cells.end());
+}
+
+CASE("wind drought detection on model levels") {
+    size_t modelLevel = 1;
+    WindDroughtFixture fixture(2);
+    auto config = windDroughtConfig(2.0, 10, std::nullopt, modelLevel);
+    WindDrought event(config, fixture.data, fixture.coarseMapping);
+
+    fixture.setValues({1.0, 1.0, 3.0}, {0.5, 0.5, 1.5}, modelLevel - 1);
+    auto first = event.detect(fixture.data);
+    EXPECT_EQUAL(first.size(), 1);
+    EXPECT(first[0].detectedCells.empty());
+
+    fixture.setValues({1.0, 1.0, 3.0}, {0.5, 0.5, 1.5}, modelLevel - 1);
+    auto second = event.detect(fixture.data);
+    EXPECT(second[0].detectedCells.empty());
+
+    fixture.setValues({1.0, 1.0, 3.0}, {0.5, 0.5, 1.5}, modelLevel - 1);
+    auto third        = event.detect(fixture.data);
+    const auto& cells = third[0].detectedCells;
+    EXPECT(cells.find(1) != cells.end());
+    EXPECT(cells.find(2) == cells.end());
+}
+
+}  // namespace test
+
+int main(int argc, char** argv) {
+    return run_tests(argc, argv);
+}

--- a/tests/events/test_wind_drought.cc
+++ b/tests/events/test_wind_drought.cc
@@ -68,15 +68,19 @@ struct WindDroughtFixture {
         data.createParam("NSTEP", 0);
     }
 
-    void setValues(const std::array<FIELD_TYPE_REAL, 3>& values, int level = 0) {
+    void setValues(const std::array<FIELD_TYPE_REAL, 3>& uValues,
+                   const std::array<FIELD_TYPE_REAL, 3>& vValues, int level = 0) {
         auto setField = [&](auto& uView, auto& vView, auto mutator) {
             for (atlas::idx_t i = 0; i < uView.shape(0); ++i) {
                 mutator(uView, i, 0, level);
                 mutator(vView, i, 0, level);
             }
-            mutator(uView, 0, values[0], level);
-            mutator(uView, 1, values[1], level);
-            mutator(uView, 2, values[2], level);
+            mutator(uView, 0, uValues[0], level);
+            mutator(uView, 1, uValues[1], level);
+            mutator(uView, 2, uValues[2], level);
+            mutator(vView, 0, vValues[0], level);
+            mutator(vView, 1, vValues[1], level);
+            mutator(vView, 2, vValues[2], level);
         };
 
         auto uView = atlas::array::make_view<FIELD_TYPE_REAL, 2>(u);
@@ -129,16 +133,16 @@ CASE("wind drought detection on height levels") {
     auto config = windDroughtConfig(2.0, 10, height);
     WindDrought event(config, fixture.data, fixture.coarseMapping);
 
-    fixture.setValues({1.0, 1.0, 3.0});
+    fixture.setValues({1.0, 1.0, 3.0}, {0.5, 0.5, 1.5});
     auto first = event.detect(fixture.data);
     EXPECT_EQUAL(first.size(), 1);
     EXPECT(first[0].detectedCells.empty());
 
-    fixture.setValues({1.0, 1.0, 3.0});
+    fixture.setValues({1.0, 1.0, 3.0}, {0.5, 0.5, 1.5});
     auto second = event.detect(fixture.data);
     EXPECT(second[0].detectedCells.empty());
 
-    fixture.setValues({1.0, 1.0, 3.0});
+    fixture.setValues({1.0, 1.0, 3.0}, {0.5, 0.5, 1.5});
     auto third        = event.detect(fixture.data);
     const auto& cells = third[0].detectedCells;
     EXPECT(cells.find(1) != cells.end());
@@ -151,16 +155,16 @@ CASE("wind drought detection on model levels") {
     auto config = windDroughtConfig(2.0, 10, std::nullopt, modelLevel);
     WindDrought event(config, fixture.data, fixture.coarseMapping);
 
-    fixture.setValues({1.0, 1.0, 3.0}, modelLevel - 1);
+    fixture.setValues({1.0, 1.0, 3.0}, {0.5, 0.5, 1.5}, modelLevel - 1);
     auto first = event.detect(fixture.data);
     EXPECT_EQUAL(first.size(), 1);
     EXPECT(first[0].detectedCells.empty());
 
-    fixture.setValues({1.0, 1.0, 3.0}, modelLevel - 1);
+    fixture.setValues({1.0, 1.0, 3.0}, {0.5, 0.5, 1.5}, modelLevel - 1);
     auto second = event.detect(fixture.data);
     EXPECT(second[0].detectedCells.empty());
 
-    fixture.setValues({1.0, 1.0, 3.0}, modelLevel - 1);
+    fixture.setValues({1.0, 1.0, 3.0}, {0.5, 0.5, 1.5}, modelLevel - 1);
     auto third        = event.detect(fixture.data);
     const auto& cells = third[0].detectedCells;
     EXPECT(cells.find(1) != cells.end());

--- a/tests/events/test_wind_drought.cc
+++ b/tests/events/test_wind_drought.cc
@@ -1,0 +1,174 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <array>
+#include <optional>
+#include <vector>
+
+#include "atlas/array.h"
+#include "atlas/field.h"
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/grid.h"
+#include "atlas/option.h"
+#include "eckit/config/LocalConfiguration.h"
+#include "eckit/exception/Exceptions.h"
+#include "eckit/testing/Test.h"
+#include "plume/data/ModelData.h"
+#include "plume/data/ParameterValue.h"
+
+#include "ee_registry/wind_drought.h"
+#include "plugin_types.h"
+
+using namespace eckit::testing;
+
+namespace {
+
+struct WindDroughtFixture {
+    plume::data::ModelData data;
+    atlas::Grid grid;
+    atlas::functionspace::NodeColumns fs;
+    std::optional<std::string> height;
+    atlas::Field u;
+    atlas::Field v;
+    std::vector<int> coarseMapping;
+
+    explicit WindDroughtFixture(int nflevg = 1, std::optional<std::string> height = std::nullopt,
+                                double tstep = 300.0) :
+        grid("O1"),
+        fs(grid, atlas::option::halo(0)),
+        height(height),
+        u(fs.createField<FIELD_TYPE_REAL>(atlas::option::name("u") |
+                                          atlas::option::levels(height.has_value() ? 1 : nflevg))),
+        v(fs.createField<FIELD_TYPE_REAL>(atlas::option::name("v") |
+                                          atlas::option::levels(height.has_value() ? 1 : nflevg))) {
+        ASSERT(u.shape(0) > 2);
+        coarseMapping.assign(u.shape(0), 0);
+        coarseMapping[0] = 1;
+        coarseMapping[1] = 1;
+        coarseMapping[2] = 2;
+
+        if (height.has_value()) {
+            nflevg = 1;
+        }
+        std::string uStr =
+            height.has_value() ? plume::data::IParameterObserver::deriveParamName("u", "hl", *height) : "u";
+        std::string vStr =
+            height.has_value() ? plume::data::IParameterObserver::deriveParamName("v", "hl", *height) : "v";
+        data.provideParam(uStr, &u);
+        data.provideParam(vStr, &v);
+        data.createParam("NFLEVG", nflevg);
+        data.createParam("TSTEP", tstep);
+        data.createParam("NSTEP", 0);
+    }
+
+    void setValues(const std::array<FIELD_TYPE_REAL, 3>& values, int level = 0) {
+        auto setField = [&](auto& uView, auto& vView, auto mutator) {
+            for (atlas::idx_t i = 0; i < uView.shape(0); ++i) {
+                mutator(uView, i, 0, level);
+                mutator(vView, i, 0, level);
+            }
+            mutator(uView, 0, values[0], level);
+            mutator(uView, 1, values[1], level);
+            mutator(uView, 2, values[2], level);
+        };
+
+        auto uView = atlas::array::make_view<FIELD_TYPE_REAL, 2>(u);
+        auto vView = atlas::array::make_view<FIELD_TYPE_REAL, 2>(v);
+        setField(uView, vView,
+                 [](auto& field, atlas::idx_t i, FIELD_TYPE_REAL value, int level) { field(i, level) = value; });
+    }
+};
+
+eckit::LocalConfiguration windDroughtConfig(double cutout, size_t timeWindow,
+                                            std::optional<std::string> height = std::nullopt, size_t modelLevel = 1) {
+    eckit::LocalConfiguration config;
+    config.set("name", "wind_drought");
+    config.set("wind_speed_cutout", cutout);
+    config.set("time_window", timeWindow);
+
+    eckit::LocalConfiguration uParam;
+    uParam.set("name", "u");
+    uParam.set("type", "ATLAS_FIELD");
+    eckit::LocalConfiguration vParam;
+    vParam.set("name", "v");
+    vParam.set("type", "ATLAS_FIELD");
+
+    if (height.has_value()) {
+        uParam.set("height", *height);
+        vParam.set("height", *height);
+    }
+    else {
+        config.set("model_level", modelLevel);
+    }
+
+    std::vector<eckit::LocalConfiguration> reqParams{uParam, vParam};
+    config.set("required_params", reqParams);
+    return config;
+}
+
+}  // namespace
+
+namespace test {
+
+CASE("wind drought setup rejects negative cutout") {
+    WindDroughtFixture fixture(1, std::string("1"));
+    auto config = windDroughtConfig(-1.0, 10, std::string("1"));
+    EXPECT_THROWS_AS(WindDrought(config, fixture.data, fixture.coarseMapping), eckit::BadValue);
+}
+
+CASE("wind drought detection on height levels") {
+    std::string height = "1";
+    WindDroughtFixture fixture(1, height);
+    auto config = windDroughtConfig(2.0, 10, height);
+    WindDrought event(config, fixture.data, fixture.coarseMapping);
+
+    fixture.setValues({1.0, 1.0, 3.0});
+    auto first = event.detect(fixture.data);
+    EXPECT_EQUAL(first.size(), 1);
+    EXPECT(first[0].detectedCells.empty());
+
+    fixture.setValues({1.0, 1.0, 3.0});
+    auto second = event.detect(fixture.data);
+    EXPECT(second[0].detectedCells.empty());
+
+    fixture.setValues({1.0, 1.0, 3.0});
+    auto third        = event.detect(fixture.data);
+    const auto& cells = third[0].detectedCells;
+    EXPECT(cells.find(1) != cells.end());
+    EXPECT(cells.find(2) == cells.end());
+}
+
+CASE("wind drought detection on model levels") {
+    size_t modelLevel = 1;
+    WindDroughtFixture fixture(2);
+    auto config = windDroughtConfig(2.0, 10, std::nullopt, modelLevel);
+    WindDrought event(config, fixture.data, fixture.coarseMapping);
+
+    fixture.setValues({1.0, 1.0, 3.0}, modelLevel - 1);
+    auto first = event.detect(fixture.data);
+    EXPECT_EQUAL(first.size(), 1);
+    EXPECT(first[0].detectedCells.empty());
+
+    fixture.setValues({1.0, 1.0, 3.0}, modelLevel - 1);
+    auto second = event.detect(fixture.data);
+    EXPECT(second[0].detectedCells.empty());
+
+    fixture.setValues({1.0, 1.0, 3.0}, modelLevel - 1);
+    auto third        = event.detect(fixture.data);
+    const auto& cells = third[0].detectedCells;
+    EXPECT(cells.find(1) != cells.end());
+    EXPECT(cells.find(2) == cells.end());
+}
+
+}  // namespace test
+
+int main(int argc, char** argv) {
+    return run_tests(argc, argv);
+}

--- a/tests/test_ee_plugin.cc
+++ b/tests/test_ee_plugin.cc
@@ -8,13 +8,22 @@
  * granted to it by virtue of its status as an intergovernmental organisation nor
  * does it submit to any jurisdiction.
  */
-#include <stdlib.h>
 #include <ctime>
+#include <map>
+#include <stdlib.h>
+#include <vector>
 
+#include "atlas/array.h"
+#include "atlas/field/detail/FieldImpl.h"
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/grid.h"
 #include "atlas/library.h"
+#include "atlas/option.h"
 #include "atlas/util/Point.h"
 #include "eckit/config/LocalConfiguration.h"
+#include "eckit/config/YAMLConfiguration.h"
 #include "eckit/testing/Test.h"
+#include "plume/data/ModelData.h"
 
 #include "ee_plugin.h"
 
@@ -59,7 +68,89 @@ CASE("test_aviso_notification") {
         unsetenv(var.first.c_str());
     }
 
-    EXPECT_THROWS_AS(notificationHandler.setSchemaData(), eckit::BadParameter);
+    EXPECT_NO_THROW(notificationHandler.setSchemaData());
+}
+
+CASE("test_setup_skips_missing_params") {
+    eckit::LocalConfiguration event;
+    event.set("name", "extreme_wind");
+    event.set("enabled", true);
+    eckit::LocalConfiguration uParam;
+    uParam.set("name", "u");
+    uParam.set("type", "ATLAS_FIELD");
+    eckit::LocalConfiguration vParam;
+    vParam.set("name", "v");
+    vParam.set("type", "ATLAS_FIELD");
+    std::vector<eckit::LocalConfiguration> reqParams{uParam, vParam};
+    event.set("required_params", reqParams);
+    event.set("instances", std::vector<eckit::LocalConfiguration>{});
+
+    eckit::LocalConfiguration conf;
+    conf.set("healpix_res", 2);
+    conf.set("enable_notification", false);
+    conf.set("aviso_url", "dummy");
+    conf.set("notify_endpoint", "dummy");
+    conf.set("events", std::vector<eckit::LocalConfiguration>{event});
+
+    ExtremeEventPlugin::EEPluginCore eePlugin(conf);
+
+    atlas::Grid grid("O1");
+    atlas::functionspace::NodeColumns fs(grid, atlas::option::halo(0));
+    auto swh = fs.createField<double>(atlas::option::name("swh") | atlas::option::levels(1));
+    plume::data::ModelData data;
+    data.provideParam("swh", &swh);
+    data.createParam("NSTEP", 0);
+    data.createParam("WSTEP", 0);
+    data.createParam("TSTEP", 900.0);
+    data.createParam("NFLEVG", 1);
+
+    eePlugin.grabData(data);
+    EXPECT_NO_THROW(eePlugin.setup());
+    EXPECT_NO_THROW(eePlugin.run());
+}
+
+CASE("test_run_extreme_wave_without_notifications") {
+    eckit::LocalConfiguration event;
+    event.set("name", "extreme_wave");
+    event.set("enabled", true);
+    eckit::LocalConfiguration swhParam;
+    swhParam.set("name", "swh");
+    swhParam.set("type", "ATLAS_FIELD");
+    event.set("required_params", std::vector<eckit::LocalConfiguration>{swhParam});
+
+    eckit::LocalConfiguration instance;
+    instance.set("threshold", 3.5);
+    instance.set("description", "test waves");
+    event.set("instances", std::vector<eckit::LocalConfiguration>{instance});
+
+    eckit::LocalConfiguration conf;
+    conf.set("healpix_res", 2);
+    conf.set("enable_notification", false);
+    conf.set("aviso_url", "dummy");
+    conf.set("notify_endpoint", "dummy");
+    conf.set("events", std::vector<eckit::LocalConfiguration>{event});
+
+    ExtremeEventPlugin::EEPluginCore eePlugin(conf);
+
+    atlas::Grid grid("O1");
+    atlas::functionspace::NodeColumns fs(grid, atlas::option::halo(0));
+    auto swh = fs.createField<double>(atlas::option::name("swh") | atlas::option::levels(1));
+    auto view = atlas::array::make_view<double, 2>(swh);
+    for (atlas::idx_t i = 0; i < view.shape(0); ++i) {
+        view(i, 0) = 4.0;
+    }
+
+    plume::data::ModelData data;
+    data.provideParam("swh", &swh);
+    data.createParam("NSTEP", 1);
+    data.createParam("WSTEP", 0);
+    data.createParam("TSTEP", 900.0);
+    data.createParam("NFLEVG", 1);
+    data.setUpdated({"swh"});
+
+    eePlugin.grabData(data);
+    eePlugin.setup();
+    EXPECT_NO_THROW(eePlugin.run());
 }
 }  // namespace test
 

--- a/tests/test_ee_plugin.cc
+++ b/tests/test_ee_plugin.cc
@@ -10,6 +10,7 @@
  */
 #include <ctime>
 #include <map>
+#include <sstream>
 #include <stdlib.h>
 #include <vector>
 
@@ -61,7 +62,15 @@ CASE("test_aviso_notification") {
     std::string data                        = R"({"hello": "world"})";
     std::vector<atlas::PointLonLat> polygon = {atlas::PointLonLat{250.3, 16.9}, atlas::PointLonLat{247.4, 14.4},
                                                atlas::PointLonLat{253.1, 14.4}, atlas::PointLonLat{250.3, 12.0}};
+    std::ostringstream capturedOutput;
+    std::streambuf* oldCout = std::cout.rdbuf(capturedOutput.rdbuf());
     EXPECT_EQUAL(notificationHandler.send(data, polygon), 999);
+    std::cout.rdbuf(oldCout);
+
+    std::string expectedLog =
+        "test/test?class=dev_class&date=dev_date&expver=dev_expver&time=dev_time&type=dev_type&"
+        "polygon=16.9,250.3,14.4,247.4,14.4,253.1,12,250.3 {\"hello\": \"world\"}\n";
+    EXPECT_EQUAL(capturedOutput.str(), expectedLog);
 
     // Unset environment variables
     for (const auto& var : vars) {
@@ -69,6 +78,9 @@ CASE("test_aviso_notification") {
     }
 
     EXPECT_NO_THROW(notificationHandler.setSchemaData());
+
+    EXPECT_THROWS_AS(ExtremeEventPlugin::AvisoNotificationHandler notificationHandlerBadEnv("test", "/test"),
+                     eckit::BadParameter);
 }
 
 CASE("test_setup_skips_missing_params") {
@@ -134,7 +146,7 @@ CASE("test_run_extreme_wave_without_notifications") {
 
     atlas::Grid grid("O1");
     atlas::functionspace::NodeColumns fs(grid, atlas::option::halo(0));
-    auto swh = fs.createField<double>(atlas::option::name("swh") | atlas::option::levels(1));
+    auto swh  = fs.createField<double>(atlas::option::name("swh") | atlas::option::levels(1));
     auto view = atlas::array::make_view<double, 2>(swh);
     for (atlas::idx_t i = 0; i < view.shape(0); ++i) {
         view(i, 0) = 4.0;

--- a/tests/test_ee_plugin.cc
+++ b/tests/test_ee_plugin.cc
@@ -8,13 +8,23 @@
  * granted to it by virtue of its status as an intergovernmental organisation nor
  * does it submit to any jurisdiction.
  */
-#include <stdlib.h>
 #include <ctime>
+#include <map>
+#include <sstream>
+#include <stdlib.h>
+#include <vector>
 
+#include "atlas/array.h"
+#include "atlas/field/detail/FieldImpl.h"
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/grid.h"
 #include "atlas/library.h"
+#include "atlas/option.h"
 #include "atlas/util/Point.h"
 #include "eckit/config/LocalConfiguration.h"
+#include "eckit/config/YAMLConfiguration.h"
 #include "eckit/testing/Test.h"
+#include "plume/data/ModelData.h"
 
 #include "ee_plugin.h"
 
@@ -52,14 +62,107 @@ CASE("test_aviso_notification") {
     std::string data                        = R"({"hello": "world"})";
     std::vector<atlas::PointLonLat> polygon = {atlas::PointLonLat{250.3, 16.9}, atlas::PointLonLat{247.4, 14.4},
                                                atlas::PointLonLat{253.1, 14.4}, atlas::PointLonLat{250.3, 12.0}};
+    std::ostringstream capturedOutput;
+    std::streambuf* oldCout = std::cout.rdbuf(capturedOutput.rdbuf());
     EXPECT_EQUAL(notificationHandler.send(data, polygon), 999);
+    std::cout.rdbuf(oldCout);
+
+    std::string expectedLog =
+        "test/test?class=dev_class&date=dev_date&expver=dev_expver&time=dev_time&type=dev_type&"
+        "polygon=16.9,250.3,14.4,247.4,14.4,253.1,12,250.3 {\"hello\": \"world\"}\n";
+    EXPECT_EQUAL(capturedOutput.str(), expectedLog);
 
     // Unset environment variables
     for (const auto& var : vars) {
         unsetenv(var.first.c_str());
     }
 
-    EXPECT_THROWS_AS(notificationHandler.setSchemaData(), eckit::BadParameter);
+    EXPECT_NO_THROW(notificationHandler.setSchemaData());
+
+    EXPECT_THROWS_AS(ExtremeEventPlugin::AvisoNotificationHandler notificationHandlerBadEnv("test", "/test"),
+                     eckit::BadParameter);
+}
+
+CASE("test_setup_skips_missing_params") {
+    eckit::LocalConfiguration event;
+    event.set("name", "extreme_wind");
+    event.set("enabled", true);
+    eckit::LocalConfiguration uParam;
+    uParam.set("name", "u");
+    uParam.set("type", "ATLAS_FIELD");
+    eckit::LocalConfiguration vParam;
+    vParam.set("name", "v");
+    vParam.set("type", "ATLAS_FIELD");
+    std::vector<eckit::LocalConfiguration> reqParams{uParam, vParam};
+    event.set("required_params", reqParams);
+    event.set("instances", std::vector<eckit::LocalConfiguration>{});
+
+    eckit::LocalConfiguration conf;
+    conf.set("healpix_res", 2);
+    conf.set("enable_notification", false);
+    conf.set("aviso_url", "dummy");
+    conf.set("notify_endpoint", "dummy");
+    conf.set("events", std::vector<eckit::LocalConfiguration>{event});
+
+    ExtremeEventPlugin::EEPluginCore eePlugin(conf);
+
+    atlas::Grid grid("O1");
+    atlas::functionspace::NodeColumns fs(grid, atlas::option::halo(0));
+    auto swh = fs.createField<double>(atlas::option::name("swh") | atlas::option::levels(1));
+    plume::data::ModelData data;
+    data.provideParam("swh", &swh);
+    data.createParam("NSTEP", 0);
+    data.createParam("WSTEP", 0);
+    data.createParam("TSTEP", 900.0);
+    data.createParam("NFLEVG", 1);
+
+    eePlugin.grabData(data);
+    EXPECT_NO_THROW(eePlugin.setup());
+    EXPECT_NO_THROW(eePlugin.run());
+}
+
+CASE("test_run_extreme_wave_without_notifications") {
+    eckit::LocalConfiguration event;
+    event.set("name", "extreme_wave");
+    event.set("enabled", true);
+    eckit::LocalConfiguration swhParam;
+    swhParam.set("name", "swh");
+    swhParam.set("type", "ATLAS_FIELD");
+    event.set("required_params", std::vector<eckit::LocalConfiguration>{swhParam});
+
+    eckit::LocalConfiguration instance;
+    instance.set("threshold", 3.5);
+    instance.set("description", "test waves");
+    event.set("instances", std::vector<eckit::LocalConfiguration>{instance});
+
+    eckit::LocalConfiguration conf;
+    conf.set("healpix_res", 2);
+    conf.set("enable_notification", false);
+    conf.set("aviso_url", "dummy");
+    conf.set("notify_endpoint", "dummy");
+    conf.set("events", std::vector<eckit::LocalConfiguration>{event});
+
+    ExtremeEventPlugin::EEPluginCore eePlugin(conf);
+
+    atlas::Grid grid("O1");
+    atlas::functionspace::NodeColumns fs(grid, atlas::option::halo(0));
+    auto swh  = fs.createField<double>(atlas::option::name("swh") | atlas::option::levels(1));
+    auto view = atlas::array::make_view<double, 2>(swh);
+    for (atlas::idx_t i = 0; i < view.shape(0); ++i) {
+        view(i, 0) = 4.0;
+    }
+
+    plume::data::ModelData data;
+    data.provideParam("swh", &swh);
+    data.createParam("NSTEP", 1);
+    data.createParam("WSTEP", 0);
+    data.createParam("TSTEP", 900.0);
+    data.createParam("NFLEVG", 1);
+    data.setUpdated({"swh"});
+
+    eePlugin.grabData(data);
+    eePlugin.setup();
+    EXPECT_NO_THROW(eePlugin.run());
 }
 }  // namespace test
 


### PR DESCRIPTION
### Description

The first commit is a bugfix, the second commit is the events and plugin core refactor to be compatible with the Plume changes introduced in this [PR](https://github.com/ecmwf/plume/pull/23) due to GRIB2 migration. [outdated] Only the storm event and necessary registry and plugin core setups have been implemented for now to get feedback on the new end to end usage of the Plume height level feature.

[Solved] Some important points need to be discussed, especially the atlas field dimensions for 2d vs. 3d which imply some code redundancy depending on the selected data structure for the derived wind fields, see [comment](https://github.com/ecmwf/plume/pull/23/changes#r2833937429) on Plume PR.

The emulator tests do not pass at the moment because of a bug in the emulator core to be fixed in Plume, but all events tests should pass.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 